### PR TITLE
fix(TcpSocket) : fix syntax error

### DIFF
--- a/srcs/socket/tcp_socket.cc
+++ b/srcs/socket/tcp_socket.cc
@@ -45,7 +45,7 @@ TcpSocket::TcpSocket(std::string const &port_number) try
   const int sock_reuse_opt = 1;
   if (setsockopt(socket_fd_, SOL_SOCKET, SO_REUSEADDR, &sock_reuse_opt,
                  sizeof(sock_reuse_opt)) == -1)
-    throw std::runtime_error(JUST1RCE_SRCS_SOCKET_SET_`OPTION_ERROR);
+    throw std::runtime_error(JUST1RCE_SRCS_SOCKET_SET_OPTION_ERROR);
 
   if (bind(socket_fd_, reinterpret_cast<struct sockaddr *>(&inet_sock_address_),
            kInetSocketAddrLen) == -1)


### PR DESCRIPTION
syntax error caused by kenW

# fix syntax error \#16 
## Overview
오타로 인한 문법 오류

<!---- Resolves: #(Isuue Number) -->
## PR Type
오타 수정

- [ ] feat
- [x] fix
- [ ] Chore(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] refactoring
- [ ] comment
- [ ] documentation
- [ ] tests
- [ ] build
- [ ] modify files
- [ ] delete files

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
