### PR TITLE
feat(TcpSocket) : erase unnecessary try-catch statement

### DIFF
--- a/srcs/socket/tcp_socket.cc
+++ b/srcs/socket/tcp_socket.cc
@@ -29,7 +29,7 @@ socklen_t const Just1RCe::TcpSocket::kInetSocketAddrLen =
  * @throws std::runtime_error with error message
  *
  */
-TcpSocket::TcpSocket(std::string const &port_number) try
+TcpSocket::TcpSocket(std::string const &port_number)
     : cur_inet_sock_addr_len_(kInetSocketAddrLen),
       socket_fd_(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)),
       is_listen_only_(true) {
@@ -59,10 +59,6 @@ TcpSocket::TcpSocket(std::string const &port_number) try
   if (flag == -1) throw std::runtime_error(JUST1RCE_SRCS_FCNTL_GETFL_ERROR);
   if (fcntl(socket_fd_, F_SETFL, flag | O_NONBLOCK) == -1)
     throw std::runtime_error(JUST1RCE_SRCS_FCNTL_SETFL_ERROR);
-
-} catch (const std::exception &e) {
-  std::cerr << e.what() << '\n';
-  throw;
 }
 
 /**
@@ -76,7 +72,7 @@ TcpSocket::TcpSocket(std::string const &port_number) try
  * @throws std::runtime_error with error message
  *
  */
-TcpSocket::TcpSocket(int const listen_sock_fd) try
+TcpSocket::TcpSocket(int const listen_sock_fd)
     : cur_inet_sock_addr_len_(kInetSocketAddrLen),
       socket_fd_(
           accept(listen_sock_fd,
@@ -99,10 +95,6 @@ TcpSocket::TcpSocket(int const listen_sock_fd) try
   if (flag == -1) throw std::runtime_error(JUST1RCE_SRCS_FCNTL_GETFL_ERROR);
   if (fcntl(socket_fd_, F_SETFL, flag | O_NONBLOCK) == -1)
     throw std::runtime_error(JUST1RCE_SRCS_FCNTL_SETFL_ERROR);
-
-} catch (const std::exception &e) {
-  std::cerr << e.what() << '\n';
-  throw;
 }
 
 /**


### PR DESCRIPTION
# Overview

TcpSocket 객체의 두 생성자에서 실행되는 불필요한 try-catch 구문을 제거함

해당 구문을 제거하는 이유는 exception을 관리하는 데에 있어서 일관성을 추구하기 위함 모든 exceptioni은 객체 내부가 아닌, 해당 객체를 불러서 쓰는 main routine에서 catch하도록 합의되었음.

<!---- Resolves: #(Isuue Number) -->
## PR Type
어떤 변경 사항이 있나요?

- [x] feat

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
