### PR TITLE
38 feat edge trigger based client

### DIFF
--- a/srcs/client/client_get_messages.cc
+++ b/srcs/client/client_get_messages.cc
@@ -18,7 +18,7 @@ namespace Just1RCe {
  * @param fd fd of the socket
  * @param buffer buffer to save received text
  */
-static bool recv_and_append_buffer(int const fd, std::string &buffer) {
+static bool recv_and_append_buffer(int const fd, std::string *pbuffer) {
   char recv_buffer[JUST1RCE_SRCS_CLIENT_MSG_MAX + 1];
   ssize_t recv_size = 0;
 
@@ -34,7 +34,7 @@ static bool recv_and_append_buffer(int const fd, std::string &buffer) {
       throw std::runtime_error(JUST1RCE_SRCS_CLIENT_RECV_ERROR);
     }
     // recv succed, append buffer with the received text
-    buffer.append(recv_buffer, recv_size);
+    pbuffer->append(recv_buffer, recv_size);
   }
   return true;
 }
@@ -42,21 +42,21 @@ static bool recv_and_append_buffer(int const fd, std::string &buffer) {
 /**
  * @brief split result with CR-LF
  */
-static std::vector<std::string> split_string_with_crlf(std::string &str) {
+static std::vector<std::string> split_string_with_crlf(std::string *pstr) {
   std::vector<std::string> buffered_messages;
   size_t start_pos = 0, end_pos = 0;
 
-  while ((end_pos = str.find(JUST1RCE_SRCS_CLIENT_MESSAGE_DELIM, start_pos)) !=
-         std::string::npos) {
+  while ((end_pos = pstr->find(JUST1RCE_SRCS_CLIENT_MESSAGE_DELIM,
+                               start_pos)) != std::string::npos) {
     // get whole message from str
-    buffered_messages.push_back(str.substr(start_pos, (end_pos - start_pos)));
+    buffered_messages.push_back(pstr->substr(start_pos, (end_pos - start_pos)));
 
     // move start position to search next delimeter delimeter
     start_pos = end_pos + 2;  // move after cr-lf
   }
   // save left over text
   // erase used messages
-  if (start_pos != 0) str = str.substr(start_pos, str.size() - start_pos);
+  if (start_pos != 0) *pstr = pstr->substr(start_pos, pstr->size() - start_pos);
   return buffered_messages;
 }
 
@@ -66,11 +66,11 @@ static std::vector<std::string> split_string_with_crlf(std::string &str) {
  * @throws runtime error, recv failure
  */
 ft::optional<std::vector<std::string> > Client::GetReceivedMessages() {
-  if (!recv_and_append_buffer(this->socket_.socket_fd(), this->read_buffer_))
+  if (!recv_and_append_buffer(this->socket_.socket_fd(), &(this->read_buffer_)))
     return ft::optional<std::vector<std::string> >();
 
   return ft::optional<std::vector<std::string> >(
-      split_string_with_crlf(this->read_buffer_));
+      split_string_with_crlf(&(this->read_buffer_)));
 }
 
 }  // namespace Just1RCe

--- a/srcs/client/client_get_messages.cc
+++ b/srcs/client/client_get_messages.cc
@@ -15,8 +15,12 @@ namespace Just1RCe {
 
 /**
  * @brief recv text from socket's fd and append text to the buffer
- * @param fd fd of the socket
- * @param buffer buffer to save received text
+ * @details append pbuffer with the text from fd's socket till the system buffer
+ * is empty.
+ * @throw Throw runtime exception if the recv calls failed.
+ * @param fd fd of the socket to recv
+ * @param pbuffer pointer to the buffer to save received text
+ * @return if the recv succeed, return true.
  */
 static bool recv_and_append_buffer(int const fd, std::string *pbuffer) {
   char recv_buffer[JUST1RCE_SRCS_CLIENT_MSG_MAX + 1];
@@ -40,7 +44,11 @@ static bool recv_and_append_buffer(int const fd, std::string *pbuffer) {
 }
 
 /**
- * @brief split result with CR-LF
+ * @brief split string with CR-LF
+ * @details Split string with "\r\n" and save them to the vector of string.
+ * Splitted strings does not contain "\r\n".
+ * @param pstr pointer to the string to split
+ * @return vector of splitted string
  */
 static std::vector<std::string> split_string_with_crlf(std::string *pstr) {
   std::vector<std::string> buffered_messages;
@@ -61,8 +69,8 @@ static std::vector<std::string> split_string_with_crlf(std::string *pstr) {
 }
 
 /**
- * @brief receive raw text from socket and turn it to propeer messages
- * @return vector of strings
+ * @brief receive all the text from socket and turn it to propeer messages
+ * @return optional vector of messages(strings)
  * @throws runtime error, recv failure
  */
 ft::optional<std::vector<std::string> > Client::GetReceivedMessages() {

--- a/srcs/client/client_get_messages.cc
+++ b/srcs/client/client_get_messages.cc
@@ -14,59 +14,63 @@ extern "C" {
 namespace Just1RCe {
 
 /**
+ * @brief recv text from socket's fd and append text to the buffer
+ * @param fd fd of the socket
+ * @param buffer buffer to save received text
+ */
+static bool recv_and_append_buffer(int const fd, std::string &buffer) {
+  char recv_buffer[JUST1RCE_SRCS_CLIENT_MSG_MAX + 1];
+  ssize_t recv_size = 0;
+
+  memset(recv_buffer, '\0', JUST1RCE_SRCS_CLIENT_MSG_MAX + 1);
+  while (recv_size = recv(fd, recv_buffer, JUST1RCE_SRCS_CLIENT_MSG_MAX, 0)) {
+    // recv failed
+    if (recv_size == -1) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        return false;  // empty option,
+                       // equivalent to
+                       // std::noops
+      }
+      throw std::runtime_error(JUST1RCE_SRCS_CLIENT_RECV_ERROR);
+    }
+    // recv succed, append buffer with the received text
+    buffer.append(recv_buffer, recv_size);
+  }
+  return true;
+}
+
+/**
+ * @brief split result with CR-LF
+ */
+static std::vector<std::string> split_string_with_crlf(std::string &str) {
+  std::vector<std::string> buffered_messages;
+  size_t start_pos = 0, end_pos = 0;
+
+  while ((end_pos = str.find(JUST1RCE_SRCS_CLIENT_MESSAGE_DELIM, start_pos)) !=
+         std::string::npos) {
+    // get whole message from str
+    buffered_messages.push_back(str.substr(start_pos, (end_pos - start_pos)));
+
+    // move start position to search next delimeter delimeter
+    start_pos = end_pos + 2;  // move after cr-lf
+  }
+  // save left over text
+  // erase used messages
+  if (start_pos != 0) str = str.substr(start_pos, str.size() - start_pos);
+  return buffered_messages;
+}
+
+/**
  * @brief receive raw text from socket and turn it to propeer messages
  * @return vector of strings
  * @throws runtime error, recv failure
  */
 ft::optional<std::vector<std::string> > Client::GetReceivedMessages() {
-  char recv_buffer[JUST1RCE_SRCS_CLIENT_MSG_MAX + 1];
-  memset(recv_buffer, '\0', JUST1RCE_SRCS_CLIENT_MSG_MAX + 1);
+  if (!recv_and_append_buffer(this->socket_.socket_fd(), this->read_buffer_))
+    return ft::optional<std::vector<std::string> >();
 
-  // recv text data from socket till the socket's buffer is empty
-  ssize_t total_recv_size = 0, recv_size = 0;
-  while (recv_size = recv(socket_.socket_fd(), recv_buffer,
-                          JUST1RCE_SRCS_CLIENT_MSG_MAX, 0)) {
-    // recv failed
-    if (recv_size == -1) {
-      if (errno == EAGAIN || errno == EWOULDBLOCK) {
-        return ft::optional<std::vector<std::string> >();  // empty option,
-                                                           // equivalent to
-                                                           // std::noops
-      }
-      throw std::runtime_error(JUST1RCE_SRCS_CLIENT_RECV_ERROR);
-    }
-    // recv succed, append read_buffer_ with the received text
-    read_buffer_.append(recv_buffer, recv_size);
-    total_recv_size += recv_size;
-  }
-
-  // get result
-  ft::optional<std::vector<std::string> > buffered_messages;
-  size_t start_pos = 0, end_pos = 0;
-  if (total_recv_size > 0) {
-    // split result with delimeter
-    while ((end_pos = read_buffer_.find(JUST1RCE_SRCS_CLIENT_MESSAGE_DELIM,
-                                        start_pos)) != std::string::npos) {
-      // result is option, use after initialization
-      if (!buffered_messages.has_value()) {
-        *buffered_messages = std::vector<std::string>();
-      }
-
-      // get whole message from read_buffer and push
-      (*buffered_messages)
-          .push_back(read_buffer_.substr(start_pos, (end_pos - start_pos)));
-
-      // move search position
-      start_pos = end_pos + 2;  // move after cr-lf
-    }
-  }
-  // save left over text
-  // erase used messages
-  if (start_pos != 0)
-    read_buffer_ =
-        read_buffer_.substr(start_pos, read_buffer_.size() - start_pos);
-
-  return buffered_messages;
+  return ft::optional<std::vector<std::string> >(
+      split_string_with_crlf(this->read_buffer_));
 }
 
 }  // namespace Just1RCe


### PR DESCRIPTION
# edge trigger한 소켓 IO  \#38
## Overview
EPOLLET 옵션(edge triggered한 socket 관리)에 보다 적합하도록 socket에 대한 recv/send 관련 루틴을 개선함

- GetReceivedMessages : socket의 read buffer가 빌 때 까지 recv하도록 변경하여 한 번에 event로 모든 데이터 recv함.
- SetSendMessage / SendMessage : EPOLLET 옵션 관련하여 주석을 추가함.

<!---- Resolves: #(Isuue Number) -->
## PR Type
어떤 변경 사항이 있나요?

- [x] feat
- [x] comment

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
