### PR TITLE
48 feat user mode per channel

### DIFF
--- a/includes/client.h
+++ b/includes/client.h
@@ -6,14 +6,6 @@
 #define JUST1RCE_SRCS_CLIENT_RECV_ERROR "Client : recv failed."
 #define JUST1RCE_SRCS_CLIENT_SEND_ERROR "Client : send failed."
 
-// Mod flags
-// describes client's permission, bitmasking
-#define JUST1RCE_SRCS_CLIENT_MOD_INVISIBLE 0b000001
-#define JUST1RCE_SRCS_CLIENT_MOD_WALLOPS 0b000010
-#define JUST1RCE_SRCS_CLIENT_MOD_OPERATOR 0b000100
-#define JUST1RCE_SRCS_CLIENT_MOD_REGISTERED 0b001000
-#define JUST1RCE_SRCS_CLIENT_MOD_RECEIVE_SERVER 0b010000
-
 #define JUST1RCE_SRCS_CLIENT_MSG_MAX 512UL
 #define JUST1RCE_SRCS_CLIENT_MESSAGE_DELIM "\r\n"
 
@@ -50,7 +42,6 @@ class Client {
   std::string server_name_;
 
   // status info
-  uint mode_mask_;
   std::string away_msg_;
 
   // per socket IO buffer, saving unsufficient message
@@ -80,12 +71,7 @@ class Client {
   std::string GetHostName() const;
   std::string GetPortNum() const;
 
-  // mode control
-  std::string GetModeAsString() const;
-  void SetMode(uint const flags);
-  void UnsetMode(uint const flags);
-  bool CheckMode(uint const flags) const;
-
+  // buffered io
   ft::optional<std::vector<std::string> > GetReceivedMessages();
 
   void SetSendMessage(std::string const &message);

--- a/includes/client_mode.h
+++ b/includes/client_mode.h
@@ -17,8 +17,8 @@ typedef unsigned int ClientModeMask;
 #define JUST1RCE_SRCS_CLIENT_MOD_RECEIVE_SERVER 0b010000
 
 std::string ConvertModeToString(ClientModeMask const target);
-inline void AddFlagsToMode(ClientModeMask &target, ClientModeMask const flags);
-inline void SubFlagsFromMode(ClientModeMask &target,
+inline void AddFlagsToMode(ClientModeMask *target, ClientModeMask const flags);
+inline void SubFlagsFromMode(ClientModeMask *target,
                              ClientModeMask const flags);
 inline bool CheckMode(ClientModeMask const target,
                       ClientModeMask const to_find);

--- a/includes/client_mode.h
+++ b/includes/client_mode.h
@@ -1,0 +1,28 @@
+
+#ifndef JUST1RCE_SRCS_CLIENT_MODE_H
+#define JUST1RCE_SRCS_CLIENT_MODE_H
+
+#include <string>
+
+namespace Just1RCe {
+
+typedef unsigned int ClientModeMask;
+
+// Mod flags
+// describes client's permission, bitmasking
+#define JUST1RCE_SRCS_CLIENT_MOD_INVISIBLE 0b000001
+#define JUST1RCE_SRCS_CLIENT_MOD_WALLOPS 0b000010
+#define JUST1RCE_SRCS_CLIENT_MOD_OPERATOR 0b000100
+#define JUST1RCE_SRCS_CLIENT_MOD_REGISTERED 0b001000
+#define JUST1RCE_SRCS_CLIENT_MOD_RECEIVE_SERVER 0b010000
+
+std::string ConvertModeToString(ClientModeMask const target);
+inline void AddFlagsToMode(ClientModeMask &target, ClientModeMask const flags);
+inline void SubFlagsFromMode(ClientModeMask &target,
+                             ClientModeMask const flags);
+inline bool CheckMode(ClientModeMask const target,
+                      ClientModeMask const to_find);
+
+}  // namespace Just1RCe
+
+#endif

--- a/includes/dbcontext.h
+++ b/includes/dbcontext.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "client_mode.h"
+#include "../includes/client_mode.h"
 
 namespace Just1RCe {
 

--- a/includes/dbcontext.h
+++ b/includes/dbcontext.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "client_mode.h"
+
 namespace Just1RCe {
 
 class Channel;
@@ -38,6 +40,19 @@ class DbContext {
 
   virtual Channel *GetChannelByName(std::string const &channel_name) = 0;
   virtual size_t GetUserNumOfChannelByName(std::string const &channel_name) = 0;
+
+  // client mode table
+  virtual void SetClientMode(std::string const &channel_name,
+                             std::string const &client_name,
+                             ClientModeMask mask) = 0;
+  virtual ClientModeMask GetClientMode(std::string const &channel_name,
+                                       std::string const &client_name) = 0;
+  virtual void DeleteClientMode(std::string const &channel_name,
+                                std::string const &client_name) = 0;
+  virtual void DeleteClientModesByClientName(
+      std::string const &client_name) = 0;
+  virtual void DeleteClientModesByChannelName(
+      std::string const &channel_name) = 0;
 
   // mapping table between channel and client
   virtual bool JoinClientToChannelByNames(std::string const &client_nick_name,

--- a/srcs/client/client_mode.cc
+++ b/srcs/client/client_mode.cc
@@ -1,51 +1,59 @@
 
-#include <string>
+#include "../../includes/client_mode.h"
 
-#include "../../includes/client.h"
+#include <string>
 
 namespace Just1RCe {
 
 /**
  * @brief stringify current mode of the client
+ * @param target target mask to be converted
  * @return formatted mode of client
  * @throws none
  */
-std::string Client::GetModeAsString() const {
+std::string ConvertModeToString(ClientModeMask const target) {
   std::string result("+");
-  if (mode_mask_ & JUST1RCE_SRCS_CLIENT_MOD_INVISIBLE) result.push_back('i');
-  if (mode_mask_ & JUST1RCE_SRCS_CLIENT_MOD_WALLOPS) result.push_back('w');
-  if (mode_mask_ & JUST1RCE_SRCS_CLIENT_MOD_OPERATOR) result.push_back('o');
-  if (mode_mask_ & JUST1RCE_SRCS_CLIENT_MOD_REGISTERED) result.push_back('r');
-  if (mode_mask_ & JUST1RCE_SRCS_CLIENT_MOD_RECEIVE_SERVER)
-    result.push_back('s');
+  if (target & JUST1RCE_SRCS_CLIENT_MOD_INVISIBLE) result.push_back('i');
+  if (target & JUST1RCE_SRCS_CLIENT_MOD_WALLOPS) result.push_back('w');
+  if (target & JUST1RCE_SRCS_CLIENT_MOD_OPERATOR) result.push_back('o');
+  if (target & JUST1RCE_SRCS_CLIENT_MOD_REGISTERED) result.push_back('r');
+  if (target & JUST1RCE_SRCS_CLIENT_MOD_RECEIVE_SERVER) result.push_back('s');
 
   return result;
 }
 
 /**
  * @brief set bitset of flags to the client's mode
+ * @param target target mask to add flags
  * @param flags bitset of flags to set
  * @return none
  * @throws none
  */
-void Client::SetMode(uint const flags) { mode_mask_ |= flags; }
+inline void AddFlagsToMode(ClientModeMask &target, ClientModeMask const flags) {
+  target |= flags;
+}
 
 /**
  * @brief unset bitset of flags to the client's mode
+ * @param target target mask to sub flags
  * @param flags bitset of flags to unset
  * @return none
  * @throws none
  */
-void Client::UnsetMode(uint const flags) { mode_mask_ &= ~flags; }
+inline void SubFlagsFromMode(ClientModeMask &target,
+                             ClientModeMask const flags) {
+  target &= ~flags;
+}
 
 /**
  * @brief chekc currently setted mode of the client
+ * @param target mode to compare with
  * @param flags bitset of flags to compare
  * @return true if all the mask in the flags are setted.
  * @throws none
  */
-bool Client::CheckMode(uint const flags) const {
-  return (flags & mode_mask_) == flags;
+inline bool CheckMode(ClientModeMask const target, ClientModeMask const flags) {
+  return (flags & target) == flags;
 }
 
 }  // namespace Just1RCe

--- a/srcs/client/client_mode.cc
+++ b/srcs/client/client_mode.cc
@@ -29,8 +29,8 @@ std::string ConvertModeToString(ClientModeMask const target) {
  * @return none
  * @throws none
  */
-inline void AddFlagsToMode(ClientModeMask &target, ClientModeMask const flags) {
-  target |= flags;
+inline void AddFlagsToMode(ClientModeMask *target, ClientModeMask const flags) {
+  *target |= flags;
 }
 
 /**
@@ -40,9 +40,9 @@ inline void AddFlagsToMode(ClientModeMask &target, ClientModeMask const flags) {
  * @return none
  * @throws none
  */
-inline void SubFlagsFromMode(ClientModeMask &target,
+inline void SubFlagsFromMode(ClientModeMask *target,
                              ClientModeMask const flags) {
-  target &= ~flags;
+  *target &= ~flags;
 }
 
 /**


### PR DESCRIPTION
# 채널별 사용자 모드 관련 수정 \#48
## Overview
기존의 모드 관련 구현은 사용자(client)가 하나의 채널에만 가입할 수 있다는 점을 전제로 하고, client객체가 mode를 소유하는 방식으로 구현했음. 하지만, 이 부분은 틀렸고, 사용자의 권한은 채널마다 존재함. 따라서 이 부분을 위한 수정이 진행되어야 함.

- client.h에서 mode 관련 내용 삭제
- 기존의 mode 관련 내용을 client_mode.h로 이동
- 이동한 mode관련 메서드의 이름을 변경(함수로 변경되었음)
- DbContext 인터페이스에 mode관련 순수 가상 함수 추가

## PR Type

- [x] feat
- [x] fix
- [x] refactoring

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
