### PR TITLE
#53 테스트용 클라이언트 2개, 서버 1개

### DIFF
--- a/tests/test_client_for_commands-1.cc
+++ b/tests/test_client_for_commands-1.cc
@@ -1,0 +1,137 @@
+// codespace, linux 용 클라이언트
+
+#include <iostream>
+#include <string>
+#include <cstring>
+#include <stdexcept>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <thread>
+
+class IRCClient {
+public:
+    IRCClient(const std::string& ip, int port)
+        : ip_(ip), port_(port), sockfd_(-1) {}
+
+    ~IRCClient() {
+        if (sockfd_ != -1) {
+            close(sockfd_);
+        }
+    }
+
+    void connectToServer() {
+        sockfd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (sockfd_ < 0) {
+            throw std::runtime_error("Error creating socket");
+        }
+
+        struct sockaddr_in server_addr;
+        std::memset(&server_addr, 0, sizeof(server_addr));
+        server_addr.sin_family = AF_INET;
+        server_addr.sin_port = htons(port_);
+
+        if (inet_pton(AF_INET, ip_.c_str(), &server_addr.sin_addr) <= 0) {
+            throw std::runtime_error("Invalid IP address or address not supported");
+        }
+
+        if (connect(sockfd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
+            throw std::runtime_error("Connection failed");
+        }
+
+        std::cout << "Connected to " << ip_ << ":" << port_ << std::endl;
+
+        std::thread receive_thread([this]() { this->receiveMessages(); });
+        receive_thread.detach();
+
+        inputLoop();
+    }
+
+private:
+    void sendCommand(const std::string& command) {
+        std::string formatted_command = command + "\r\n";
+        if (send(sockfd_, formatted_command.c_str(), formatted_command.size(), 0) < 0) {
+            throw std::runtime_error("Failed to send command: " + command);
+        }
+    }
+
+    void receiveMessages() {
+        char buffer[4096];
+        std::string nickname;
+
+        while (true) {
+            std::memset(buffer, 0, sizeof(buffer));
+            int bytes_received = recv(sockfd_, buffer, sizeof(buffer) - 1, 0);
+            if (bytes_received <= 0) {
+                std::cout << "Disconnected from server." << std::endl;
+                break;
+            }
+            std::string message(buffer);
+            std::cout << "[RECEIVED]: " << message;
+
+            if (message.find("PING") == 0) {
+                std::string pong_response = message;
+                pong_response.replace(0, 4, "PONG");
+                std::cout << "[DEBUG] Responding to PING with: " << pong_response << std::endl;
+                sendCommand(pong_response);
+            }
+            else if (message.find("PRIVMSG ") != std::string::npos && message.find(" :VERSION") != std::string::npos) {
+                std::size_t start = message.find(":") + 1;
+                std::size_t end = message.find("!");
+                if (start != std::string::npos && end != std::string::npos) {
+                    nickname = message.substr(start, end - start);
+                }
+                sendCommand("NOTICE " + nickname + " :\001VERSION IRCClient 1.0\001");
+            }
+            else if (message.find("NOTICE * :*** No Ident response") != std::string::npos) {
+                if (!nickname.empty()) {
+                    sendCommand("USER " + nickname + " " + nickname + " irc.rizon.net :" + nickname);
+                }
+            }
+        }
+    }
+
+    void inputLoop() {
+        std::string input;
+        while (true) {
+            std::getline(std::cin, input);
+            if (input.empty()) continue;
+
+            sendCommand(input);
+
+            if (input == "QUIT") {
+                break;
+            }
+        }
+    }
+
+    std::string ip_;
+    int port_;
+    int sockfd_;
+};
+
+int main() {
+    try {
+        int option;
+        std::cout << "Enter 1 to connect to the default server, or any other number to enter a custom server: ";
+        std::cin >> option;
+        std::cin.ignore();
+
+        std::string ip;
+        int port;
+
+        if (option == 1) {
+            ip = "52.193.79.145";
+            port = 6667;
+        } else {
+            ip = "127.0.0.1";
+            port = 6667;
+        }
+
+        IRCClient client(ip, port);
+        client.connectToServer();
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/tests/test_client_for_commands_mac_realtime-1.cc
+++ b/tests/test_client_for_commands_mac_realtime-1.cc
@@ -1,0 +1,130 @@
+// g++ -o client_test -std=c++11 tests/test_client_for_commands_mac_realtime.cc
+// ./client_test
+// 상용서버 rizon.net에 접속하고 싶으면 1, localhost에 접속하고 싶다면 아무 다른 문자를 입력한다
+// 상용서버 입장시 NICK, USER 명령어를 알맞게 입력하면 접속이 된다
+// NICK nick_name   
+// USER user_name user_name irc.rizon.net :real_name
+// 명령어를 양식에 맞게 올바르게 입력하면 서버에서 알맞은 동작을 하며 서버에서 클라이언트에게 보내는
+// 메시지 양식을 그대로 보여준다
+
+#include <iostream>
+#include <string>
+#include <cstring>
+#include <stdexcept>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <thread>
+
+class IRCClient {
+public:
+    IRCClient(const std::string& ip, int port)
+        : ip_(ip), port_(port), sockfd_(-1) {}
+
+    ~IRCClient() {
+        if (sockfd_ != -1) {
+            close(sockfd_);
+        }
+    }
+
+    void connectToServer() {
+        sockfd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (sockfd_ < 0) {
+            throw std::runtime_error("Error creating socket");
+        }
+
+        struct sockaddr_in server_addr;
+        std::memset(&server_addr, 0, sizeof(server_addr));
+        server_addr.sin_family = AF_INET;
+        server_addr.sin_port = htons(port_);
+
+        if (inet_pton(AF_INET, ip_.c_str(), &server_addr.sin_addr) <= 0) {
+            throw std::runtime_error("Invalid IP address or address not supported");
+        }
+
+        if (connect(sockfd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
+            throw std::runtime_error("Connection failed");
+        }
+
+        std::cout << "Connected to " << ip_ << ":" << port_ << std::endl;
+
+        // 🔹 std::thread에서 멤버 함수를 실행할 수 있도록 람다 표현식 사용
+        std::thread receive_thread([this]() { this->receiveMessages(); });
+        receive_thread.detach();
+
+        inputLoop();
+    }
+
+private:
+    void sendCommand(const std::string& command) {
+        std::string formatted_command = command + "\r\n";
+        if (send(sockfd_, formatted_command.c_str(), formatted_command.size(), 0) < 0) {
+            throw std::runtime_error("Failed to send command: " + command);
+        }
+    }
+
+    void receiveMessages() {
+        char buffer[4096];
+
+        while (true) {
+            std::memset(buffer, 0, sizeof(buffer));
+            int bytes_received = recv(sockfd_, buffer, sizeof(buffer) - 1, 0);
+            if (bytes_received <= 0) {
+                std::cout << "Disconnected from server." << std::endl;
+                break;
+            }
+            std::cout << "[RECEIVED]: " << buffer;
+
+            // PING 처리
+            if (std::strncmp(buffer, "PING", 4) == 0) {
+                std::string pong_response = std::string(buffer).replace(0, 4, "PONG");
+                std::cout << "[DEBUG] Responding to PING with: " << pong_response << std::endl;
+                sendCommand(pong_response);
+            }
+        }
+    }
+
+    void inputLoop() {
+        std::string input;
+        while (true) {
+            std::getline(std::cin, input);
+            if (input.empty()) continue;
+
+            sendCommand(input);
+
+            if (input == "QUIT") {
+                break;
+            }
+        }
+    }
+
+    std::string ip_;
+    int port_;
+    int sockfd_;
+};
+
+int main() {
+    try {
+        int option;
+        std::cout << "Enter 1 to connect to the default server, or any other number to enter a custom server: ";
+        std::cin >> option;
+        std::cin.ignore();  // 개행 문자 제거
+
+        std::string ip;
+        int port;
+
+        if (option == 1) {
+            ip = "52.193.79.145";  // 기본 서버 IP
+            port = 6667;            // 기본 포트
+        } else {
+            ip = "127.0.0.1";  // localhost (변경됨)
+            port = 6667;       // 기본 포트
+        }
+
+        IRCClient client(ip, port);
+        client.connectToServer();
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/tests/test_server_for_commands-1.cc
+++ b/tests/test_server_for_commands-1.cc
@@ -1,0 +1,149 @@
+// g++ -o server_test -std=c++11 tests/test_server_for_commands.cc
+// ./server_test 6667
+
+// 컴파일 후, 서버를 6667로 열고 irssi를 열어
+// /connect -nocap localhost 6667 
+// 위의 명령어를 입력하여 테스트 서버에 접속 
+// 후에 irssi에서 명령어를 입력하면 서버에 명령어가 어떤형식으로 들어오는지 알려준다   
+
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string>
+
+int main(int argc, char *argv[])
+{
+    struct addrinfo hints, *result, *rp;
+    int sfd, s;
+    char buf[512];
+    struct sockaddr_storage peer_addr;
+    socklen_t peer_addr_len;
+    ssize_t nread;
+
+    if (argc != 2)
+    {
+        fprintf(stderr, "Usage: %s port\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+
+    // Prepare the socket address hints
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET6;      // Allow IPv4 or IPv6
+    hints.ai_socktype = SOCK_STREAM; // TCP
+    hints.ai_flags = AI_PASSIVE;     // Bind to all interfaces
+
+    // Get address info
+    s = getaddrinfo(NULL, argv[1], &hints, &result);
+    if (s != 0)
+    {
+        fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(s));
+        exit(EXIT_FAILURE);
+    }
+
+    // Try to bind to one of the addresses
+    for (rp = result; rp != NULL; rp = rp->ai_next) {
+        sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (sfd == -1)
+            continue;
+
+        int opt = 1;
+        if (setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+            perror("setsockopt");
+            close(sfd);
+            continue;
+        }
+
+        if (bind(sfd, rp->ai_addr, rp->ai_addrlen) == 0)
+            break;
+
+        close(sfd);
+    }
+
+    if (rp == NULL)
+    {
+        fprintf(stderr, "Could not bind\n");
+        exit(EXIT_FAILURE);
+    }
+
+    freeaddrinfo(result);
+
+    // Listen for connections
+    if (listen(sfd, 10) == -1)
+    {
+        perror("listen");
+        exit(EXIT_FAILURE);
+    }
+
+    printf("Server listening on port %s...\n", argv[1]);
+
+    for (;;)
+    {
+        // Accept a client connection
+        peer_addr_len = sizeof(peer_addr);
+        int connfd = accept(sfd, (struct sockaddr *)&peer_addr, &peer_addr_len);
+        if (connfd == -1)
+        {
+            perror("accept");
+            continue;
+        }
+
+        printf("Client connected\n");
+
+        // Send welcome message
+        const char *welcome = ":irc.losslessone.com 001 nick_ken3 :Welcome to the Rizon Internet Relay Chat Network nick_ken3\r\n:irc.losslessone.com 002 nick_ken3 :Your host is irc.losslessone.com, running version plexus-4(hybrid-8.1.20)\r\n";
+
+        // Handle client commands
+        while ((nread = read(connfd, buf, sizeof(buf) - 1)) > 0)
+        {
+            buf[nread] = '\0';
+            printf("Received: %s", buf);
+
+            if (strncmp(buf, "NICK", 4) == 0) {
+                char new_nick[50] = {0};
+                if (sscanf(buf, "NICK %49s", new_nick) == 1) {
+                    char response[100] = {0};
+                    snprintf(response, sizeof(response), ":nick_ken3 NICK :%s\r\n", new_nick);
+                    
+                    printf("[DEBUG] Sending: %s", response);  // 로그 추가
+                    write(connfd, response, strlen(response));
+                }
+            }
+            else if (strncmp(buf, "USER", 4) == 0)
+            {
+                // Handle USER command
+                write(connfd, welcome, strlen(welcome));
+            }
+            else if (strncmp(buf, "JOIN", 4) == 0)
+            {
+                std::string servername = "Just1RCe";
+                std::string nickname = "ken";
+                std::string channel = "channel";
+
+                // JOIN 실패 메시지 작성
+                std::string response = "471 " + nickname + " " + channel + " :Cannot join channel (+l)\r\n";
+
+                // 클라이언트로 전송
+                if (write(connfd, response.c_str(), response.size()) == -1) {
+                    perror("Error writing JOIN failure response to socket");
+                } else {
+                    printf("Sent JOIN failure response: %s", response.c_str());
+                }
+            }
+            else
+            {
+                // Default response for unknown commands
+                write(connfd, ":server_name 400 user :Unknown command\r\n", 41);
+            }
+        }
+
+        printf("Client disconnected\n");
+        close(connfd);
+    }
+
+    close(sfd);
+    return 0;
+}


### PR DESCRIPTION
# 테스트용 클라이언트 2개, 서버 1개\#53
## Overview

- [x] test_client_for_commands: 코드스페이스, 리눅스 환경에서 동작하도록 만든 클라이언트
- [x] test_client_for_commands_mac_realtime: MAC 환경에서 동작하도록 만든 클라이언트
- [x] test_server_for_commands: 코드스페이스, 리눅스, MAC 환경에서 동작하도록 만든 클라이언트

자세한 사용방법은 각 파일의 상단에 주석으로 설명되어있다

