### PR TITLE
75 fix modify commandhandler interface

### DIFF
--- a/includes/command_handler.h
+++ b/includes/command_handler.h
@@ -3,6 +3,7 @@
 #define JUST1RCE_SRCS_COMMAND_HANDLER_H
 
 #include <string>
+#include <vector>
 
 namespace Just1RCe {
 
@@ -17,8 +18,15 @@ class CommandHandler {
  public:
   ~CommandHandler() {}
 
-  virtual void operator()(std::string const &nick_name,
-                          std::string const &meesage) = 0;
+  /**
+   * @brief handle command
+   * @param client_fd fd to identify client that te message originate from
+   * @param message raw text message from client, will be parsed, no trailing
+   * cr-lf
+   * @return vector of int(fd), to register write event
+   */
+  virtual std::vector<int> operator()(int const client_fd,
+                                      std::string const &meesage) = 0;
 };
 
 }  // namespace Just1RCe

--- a/includes/command_handler.h
+++ b/includes/command_handler.h
@@ -16,7 +16,7 @@ namespace Just1RCe {
  */
 class CommandHandler {
  public:
-  ~CommandHandler() {}
+  virtual ~CommandHandler() {}
 
   /**
    * @brief handle command


### PR DESCRIPTION
# modify interface CommandHandler \#75
## Overview
- DbContext에서 클라이언트의 primary key가 fd로 변경됨. 따라서 클라이언트를 식별하기 위한 매개변수를 fd로 변경
- Command의 수행 과정에서 event의 등록이 필요함. 이를 CommandHandler 외부에서 수행하기 위하여 등록이 필요한 fd를 vector에 담아서 return하도록 변경
- 소멸자에 virtual keyword를 추가

## PR Type
어떤 변경 사항이 있나요?

- [x] fix

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
