### PR TITLE
feat : modify primary key, client_nick_name -> client_fd

### DIFF
--- a/includes/dbcontext.h
+++ b/includes/dbcontext.h
@@ -26,10 +26,9 @@ class DbContext {
 
   // Client index table
   virtual bool AddClient(Client *user) = 0;
-  virtual void DelClient(std::string const &client_nick_name) = 0;
+  virtual void DelClient(int const client_fd) = 0;
 
-  virtual Client *GetClient(std::string const &client_nick_name) = 0;
-  virtual std::string GetNickNameByFd(int const fd) = 0;
+  virtual Client *GetClient(int const client_fd) = 0;
 
   // Channel index table
   virtual bool AddChannel(Channel *room) = 0;
@@ -39,23 +38,21 @@ class DbContext {
   virtual size_t GetNumOfClientInChannel(std::string const &channel_name) = 0;
 
   // client mode table
-  virtual void SetClientMode(std::string const &client_nick_name,
+  virtual void SetClientMode(int const client_fd,
                              std::string const &channel_name,
                              ClientModeMask mask) = 0;
-  virtual ClientModeMask GetClientMode(std::string const &client_nick_name,
+  virtual ClientModeMask GetClientMode(int const client_fd,
                                        std::string const &channel_name) = 0;
-  virtual void DeleteClientMode(std::string const &client_nick_name,
+  virtual void DeleteClientMode(int const client_fd,
                                 std::string const &channel_name) = 0;
-  virtual void DeleteClientModesByClientName(
-      std::string const &client_nick_name) = 0;
+  virtual void DeleteClientModesByClientFd(int const client_fd) = 0;
 
   // mapping table between channel and client
-  virtual bool JoinClientToChannel(std::string const &client_nick_name,
+  virtual bool JoinClientToChannel(int const client_fd,
                                    std::string const &channel_name) = 0;
-  virtual void PartClientFromChannel(std::string const &client_nick_name,
+  virtual void PartClientFromChannel(int const client_fd,
                                      std::string const &channel_name) = 0;
-  virtual std::vector<Channel *> GetChannelsByClientNickName(
-      std::string const &client_nick_name) = 0;
+  virtual std::vector<Channel *> GetChannelsByClientFd(int const client_fd) = 0;
   virtual std::vector<Client *> GetClientsByChannelName(
       std::string const &channel_name) = 0;
 };


### PR DESCRIPTION
# overview

수정 사항 :
- 매개변수 client_nick_name을 모두 client_fd로 변경
- 이름을 받는 일부 메서드의 이름을 변경

client의 초기화 과정에서 nick_name이 없는 순간이 존재함을 확인
따라서 nick_name은 primary key로서 부적합함을 확인
따라서 fd를 primary_key로 변경, 관련 메서드 수정함.

## PR Type
어떤 변경 사항이 있나요?

- [x] fix

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
