### PR TITLE
#94 feat: trailing처리 및 잘못 구현된 부분 수정 완료

### DIFF
--- a/includes/parser.h
+++ b/includes/parser.h
@@ -18,12 +18,15 @@ class Parser {
   std::vector<std::string> token_stream_;
   void splitBySpace(const std::string &message);
   std::vector<std::string> splitByComma(const std::string &param);
-  Parser(const Parser &rhs);
-  Parser &operator=(const Parser &rhs);
+  Parser(const Parser &);
+  Parser &operator=(const Parser &);
 
  public:
   explicit Parser(const std::string &message);
   ~Parser();
+
+  std::vector<std::string> GetTokenStream() const;
+
   const int ParseCommandNick(std::string *nickname);
   const int ParseCommandUser(std::string *username, std::string *realname);
   const int ParseCommandPing(std::string *token);

--- a/srcs/parse/parser.cc
+++ b/srcs/parse/parser.cc
@@ -66,6 +66,10 @@ std::vector<std::string> Parser::splitByComma(const std::string &param) {
   return tokens;
 }
 
+std::vector<std::string> Parser::GetTokenStream() const {
+  return token_stream_;
+}
+
 const int Parser::ParseCommandNick(std::string *nickname) {
   if (token_stream_.size() < 2) {
     return ERR_NONICKNAMEGIVEN;

--- a/srcs/parse/parser.cc
+++ b/srcs/parse/parser.cc
@@ -21,11 +21,13 @@ void Parser::splitBySpace(const std::string &message) {
   }
 
   while ((end = message.find(JUST1RCE_SPACE, start)) != std::string::npos) {
-    if (end > message.find(JUST1RCE_COLON, start)) {
-      std::string splited = message.substr(start + 1);
+    if (end < message.size() - 1 && message[end + 1] == JUST1RCE_COLON) {
+      std::string splited = message.substr(start, end - start);
       if (splited.empty() == false) {
         token_stream_.push_back(splited);
       }
+      start = end + 2;
+      token_stream_.push_back(message.substr(start));
       return;
     }
 

--- a/srcs/parse/parser.cc
+++ b/srcs/parse/parser.cc
@@ -2,7 +2,7 @@
 
 #include <string>
 #include <vector>
-
+#include <iostream>
 #include "../../includes/numeric.h"
 
 namespace Just1RCe {
@@ -16,40 +16,58 @@ Parser::~Parser() {}
 void Parser::splitBySpace(const std::string &message) {
   size_t start = 0, end;
 
-  if (message.empty()) return;
+  if (message.empty() == true) {
+    return;
+  }
 
   while ((end = message.find(JUST1RCE_SPACE, start)) != std::string::npos) {
+    if (end > message.find(JUST1RCE_COLON, start)) {
+      std::string splited = message.substr(start + 1);
+      if (splited.empty() == false) {
+        token_stream_.push_back(splited);
+      }
+      return;
+    }
+
     std::string splited = message.substr(start, end - start);
-    if (splited.size())
+    if (splited.empty() == false) {
       token_stream_.push_back(splited);
+    }
     start = end + 1;
   }
   std::string splited = message.substr(start);
-  if (splited.size())
+  if (splited.empty() == false) {
     token_stream_.push_back(splited);
+  }
 }
 
 std::vector<std::string> Parser::splitByComma(const std::string &param) {
   std::vector<std::string> tokens;
   size_t start = 0, end;
 
-  if (param.empty()) return tokens;
+  if (param.empty() == true) {
+    return tokens;
+  }
 
   while ((end = param.find(JUST1RCE_COMMA, start)) != std::string::npos) {
     std::string splited = param.substr(start, end - start);
-    if (splited.size())
+    if (splited.empty() == false) {
       tokens.push_back(splited);
+    }
     start = end + 1;
   }
   std::string splited = param.substr(start);
-  if (splited.size())
-    token_stream_.push_back(splited);
+  if (splited.empty() == false) {
+    tokens.push_back(splited);
+  }
 
   return tokens;
 }
 
 const int Parser::ParseCommandNick(std::string *nickname) {
-  if (token_stream_.size() < 2) return ERR_NONICKNAMEGIVEN;
+  if (token_stream_.size() < 2) {
+    return ERR_NONICKNAMEGIVEN;
+  }
 
   *nickname = token_stream_[1];
 
@@ -58,7 +76,9 @@ const int Parser::ParseCommandNick(std::string *nickname) {
 
 const int Parser::ParseCommandUser(std::string *username,
                                    std::string *realname) {
-  if (token_stream_.size() < 5) return ERR_NEEDMOREPARAMS;
+  if (token_stream_.size() < 5) {
+    return ERR_NEEDMOREPARAMS;
+  }
 
   *username = token_stream_[1];
   *realname = token_stream_[4];
@@ -67,7 +87,9 @@ const int Parser::ParseCommandUser(std::string *username,
 }
 
 const int Parser::ParseCommandPing(std::string *token) {
-  if (token_stream_.size() < 2) return ERR_NOORIGIN;
+  if (token_stream_.size() < 2) {
+    return ERR_NOORIGIN;
+  }
 
   *token = token_stream_[1];
 
@@ -75,26 +97,33 @@ const int Parser::ParseCommandPing(std::string *token) {
 }
 
 const int Parser::ParseCommandQuit(std::string *reason) {
-  if (token_stream_.size() < 2)
+  if (token_stream_.size() < 2) {
     *reason = JUST1RCE_DEFAULT_QUIT_COMMENT;
-  else
+  } else {
     *reason = token_stream_[1];
+  }
 
   return IRC_NOERROR;
 }
 
 const int Parser::ParseCommandJoin(std::vector<std::string> *channels,
                                    std::vector<std::string> *passwords) {
-  if (token_stream_.size() < 2) return ERR_NEEDMOREPARAMS;
+  if (token_stream_.size() < 2) {
+    return ERR_NEEDMOREPARAMS;
+  }
 
   *channels = splitByComma(token_stream_[1]);
-  if (token_stream_.size() > 2) *passwords = splitByComma(token_stream_[2]);
+  if (token_stream_.size() > 2) {
+    *passwords = splitByComma(token_stream_[2]);
+  }
 
   return IRC_NOERROR;
 }
 
 const int Parser::ParseCommandPart(std::vector<std::string> *channels) {
-  if (token_stream_.size() < 2) return ERR_NEEDMOREPARAMS;
+  if (token_stream_.size() < 2) {
+    return ERR_NEEDMOREPARAMS;
+  }
 
   *channels = splitByComma(token_stream_[1]);
 
@@ -102,13 +131,16 @@ const int Parser::ParseCommandPart(std::vector<std::string> *channels) {
 }
 
 const int Parser::ParseCommandTopic(std::string *channel, std::string *topic) {
-  if (token_stream_.size() < 2) return ERR_NEEDMOREPARAMS;
+  if (token_stream_.size() < 2) {
+    return ERR_NEEDMOREPARAMS;
+  }
 
   *channel = token_stream_[1];
-  if (token_stream_.size() > 2)
+  if (token_stream_.size() > 2) {
     *topic = token_stream_[2];
-  else
+  } else {
     *topic = "";
+  }
 
   return IRC_NOERROR;
 }
@@ -120,14 +152,18 @@ const int Parser::ParseCommandNames(std::string *channel) {
 }
 
 const int Parser::ParseCommandList(std::string *channel) {
-  if (token_stream_.size() < 2) *channel = "";
+  if (token_stream_.size() < 2) {
+    *channel = "";
+  }
 
   return IRC_NOERROR;
 }
 
 const int Parser::ParseCommandInvite(std::string *nickname,
                                      std::string *channel) {
-  if (token_stream_.size() < 3) return ERR_NEEDMOREPARAMS;
+  if (token_stream_.size() < 3) {
+    return ERR_NEEDMOREPARAMS;
+  }
 
   *nickname = token_stream_[1];
   *channel = token_stream_[2];
@@ -137,14 +173,17 @@ const int Parser::ParseCommandInvite(std::string *nickname,
 
 const int Parser::ParseCommandKick(std::string *channel, std::string *nickname,
                                    std::string *comment) {
-  if (token_stream_.size() < 3) return ERR_NEEDMOREPARAMS;
+  if (token_stream_.size() < 3) {
+    return ERR_NEEDMOREPARAMS;
+  }
 
   *channel = token_stream_[1];
   *nickname = token_stream_[2];
-  if (token_stream_.size() > 3)
+  if (token_stream_.size() > 3) {
     *comment = token_stream_[3];
-  else
+  } else {
     *comment = JUST1RCE_DEFAULT_KICK_COMMENT;
+  }
 
   return IRC_NOERROR;
 }
@@ -152,25 +191,33 @@ const int Parser::ParseCommandKick(std::string *channel, std::string *nickname,
 const int Parser::ParseCommandMode(std::string *target,
                                    std::string *mode_string,
                                    std::string *mode_argument) {
-  if (token_stream_.size() < 2) return ERR_NEEDMOREPARAMS;
+  if (token_stream_.size() < 2) {
+    return ERR_NEEDMOREPARAMS;
+  }
 
   *target = token_stream_[1];
-  if (token_stream_.size() > 2)
+  if (token_stream_.size() > 2) {
     *mode_string = token_stream_[2];
-  else
+  } else {
     *mode_string = "";
-  if (token_stream_.size() > 3)
+  }
+  if (token_stream_.size() > 3) {
     *mode_argument = token_stream_[3];
-  else
+  } else {
     *mode_argument = "";
+  }
 
   return IRC_NOERROR;
 }
 
 const int Parser::ParseCommandPrivmsg(std::string *target,
                                       std::string *text_to_send) {
-  if (token_stream_.size() < 2) return ERR_NORECIPIENT;
-  if (token_stream_.size() < 3) return ERR_NOTEXTTOSEND;
+  if (token_stream_.size() < 2) {
+    return ERR_NORECIPIENT;
+  }
+  if (token_stream_.size() < 3) {
+    return ERR_NOTEXTTOSEND;
+  }
 
   *target = token_stream_[1];
   *text_to_send = token_stream_[2];


### PR DESCRIPTION
# feat: trailing처리 및 잘못 구현된 부분 수정 완료 \#94 
## Overview
- 공백을 기준으로 token stream을 생성하는 과정에서 `:` 을 기준으로하는 trailing 파라미터 처리가 누락된 것을 확인하여 trailing을 처리해주는 기능 추가

- `,` 를 기준으로 매개변수를 나누는 작업에서 구현이 잘못된 부분을 수정
