### PR TITLE
37 feat service routine

### DIFF
--- a/includes/service.h
+++ b/includes/service.h
@@ -1,0 +1,47 @@
+
+#ifndef JUST1RCE_SRCS_SERVICE_H
+#define JUST1RCE_SRCS_SERVICE_H
+
+#define JUST1RCE_SRCS_EVENT_BUFFER_SIZE 1024
+
+#include <map>
+#include <string>
+
+namespace Just1RCe {
+
+class CommandHandler;
+typedef std::map<std::string, CommandHandler *> CommandMapping;
+
+class Service {
+ private:
+  Service();
+  Service(Service const &);
+  ~Service();
+  Service &operator=(Service const &);
+
+  // event handler
+  static void HandleServerEvent(int const epoll_fd,
+                                CommandMapping const &cmd_map,
+                                struct epoll_event const &cur_event);
+  static void HandleClientEvent(int const epoll_fd,
+                                CommandMapping const &cmd_map,
+                                struct epoll_event const &cur_event);
+  static void RunCommand(int const epoll_fd, CommandMapping const &cmd_map,
+                         struct epoll_event const &cur_event,
+                         std::string const &msg);
+
+  // event utility
+  static void RegisterServer(int const epoll_fd, int const server_fd);
+  static void RegisterClient(int const epoll_fd, int const client_fd);
+  static void UnRegisterClient(int const epoll_fd, int const client_fd);
+  static void SetWriteEvent(int const epoll_fd, int const target_fd);
+  static void SetReadEvent(int const epoll_fd, int const target_fd);
+
+ public:
+  static void RunIrcServer(std::string const &port_number,
+                           CommandMapping const &cmd_map);
+};
+
+}  // namespace Just1RCe
+
+#endif

--- a/srcs/service/event_handler.cc
+++ b/srcs/service/event_handler.cc
@@ -1,0 +1,93 @@
+
+extern "C" {
+#include <sys/epoll.h>
+}
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../../includes/client.h"
+#include "../../includes/command_handler.h"
+#include "../../includes/context_holder.h"
+#include "../../includes/dbcontext.h"
+#include "../../includes/ft_optional.h"
+#include "../../includes/service.h"
+#include "../../includes/tcp_socket.h"
+
+namespace Just1RCe {
+
+void Service::HandleServerEvent(int const epoll_fd,
+                                CommandMapping const &cmd_map,
+                                struct epoll_event const &cur_event) {
+  // check sanity of server socket
+  if (cur_event.events & (EPOLLHUP | EPOLLERR))
+    throw std::runtime_error("server socket is broken");
+
+  // add new user
+  Client *new_user = new Client(cur_event.data.fd);
+  ContextHolder::GetInstance()->db()->AddClient(new_user);
+}
+
+static std::string GetCommandFromMessage(std::string const &msg) {
+  std::stringstream ss(msg);
+  std::string first_word;
+  ss >> first_word;
+  return first_word;
+}
+
+void Service::RunCommand(int const epoll_fd, CommandMapping const &cmd_map,
+                         struct epoll_event const &cur_event,
+                         std::string const &msg) {
+  // call command handler
+  std::string const command = GetCommandFromMessage(msg);
+  std::vector<int> const fd_to_write =
+      (*(cmd_map.find(command)->second))(cur_event.data.fd, msg);
+
+  // set all messages
+  for (int i = 0; i < fd_to_write.size(); ++i)
+    SetWriteEvent(epoll_fd, fd_to_write[i]);
+}
+
+void Service::HandleClientEvent(int const epoll_fd,
+                                CommandMapping const &cmd_map,
+                                struct epoll_event const &cur_event) {
+  if (cur_event.events & (EPOLLERR | EPOLLRDHUP | EPOLLHUP)) {
+    // un expected connection broke
+    UnRegisterClient(epoll_fd, cur_event.data.fd);
+    RunCommand(epoll_fd, cmd_map, cur_event,
+               "QUIT :unexpected connection destroyed");
+    return;
+  }
+
+  // get target client
+  Client *const target =
+      ContextHolder::GetInstance()->db()->GetClient(cur_event.data.fd);
+
+  // read event
+  if (cur_event.events & EPOLLIN) {
+    ft::optional<std::vector<std::string> > messages =
+        target->GetReceivedMessages();
+    SetReadEvent(epoll_fd, cur_event.data.fd);
+
+    // run commands
+    if (messages.has_value()) {
+      for (int i = 0; i < (*messages).size(); ++i) {
+        RunCommand(epoll_fd, cmd_map, cur_event, (*messages)[i]);
+      }
+    }
+  }
+
+  // write event
+  if (cur_event.events & EPOLLOUT) {
+    bool const do_write_again = target->SendMessage();
+
+    if (do_write_again) {
+      SetWriteEvent(epoll_fd, cur_event.data.fd);
+    } else
+      SetReadEvent(epoll_fd, cur_event.data.fd);
+  }
+}
+
+}  // namespace Just1RCe

--- a/srcs/service/event_handler.cc
+++ b/srcs/service/event_handler.cc
@@ -85,8 +85,9 @@ void Service::HandleClientEvent(int const epoll_fd,
 
     if (do_write_again) {
       SetWriteEvent(epoll_fd, cur_event.data.fd);
-    } else
+    } else {
       SetReadEvent(epoll_fd, cur_event.data.fd);
+    }
   }
 }
 

--- a/srcs/service/event_utility.cc
+++ b/srcs/service/event_utility.cc
@@ -28,11 +28,7 @@ void Service::RegisterClient(int const epoll_fd, int const client_fd) {
 }
 
 void Service::UnRegisterClient(int const epoll_fd, int const client_fd) {
-  struct epoll_event event;
-
-  event.events = 0;
-  event.data.fd = client_fd;
-  if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, client_fd, &event) == -1)
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, client_fd, NULL) == -1)
     throw std::runtime_error("event register failed");
 }
 

--- a/srcs/service/event_utility.cc
+++ b/srcs/service/event_utility.cc
@@ -1,0 +1,57 @@
+
+extern "C" {
+#include <sys/epoll.h>
+}
+
+#include <stdexcept>
+
+#include "../../includes/service.h"
+
+namespace Just1RCe {
+
+void Service::RegisterServer(int const epoll_fd, int const server_fd) {
+  struct epoll_event event;
+
+  event.events = EPOLLIN | EPOLLET;
+  event.data.fd = server_fd;
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, server_fd, &event) == -1)
+    throw std::runtime_error("event register failed");
+}
+
+void Service::RegisterClient(int const epoll_fd, int const client_fd) {
+  struct epoll_event event;
+
+  event.events = EPOLLIN | EPOLLET | EPOLLONESHOT | EPOLLRDHUP;
+  event.data.fd = client_fd;
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, client_fd, &event) == -1)
+    throw std::runtime_error("event register failed");
+}
+
+void Service::UnRegisterClient(int const epoll_fd, int const client_fd) {
+  struct epoll_event event;
+
+  event.events = 0;
+  event.data.fd = client_fd;
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, client_fd, &event) == -1)
+    throw std::runtime_error("event register failed");
+}
+
+void Service::SetWriteEvent(int const epoll_fd, int const target_fd) {
+  struct epoll_event event;
+
+  event.events = EPOLLIN | EPOLLOUT | EPOLLET | EPOLLONESHOT | EPOLLRDHUP;
+  event.data.fd = target_fd;
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_MOD, target_fd, &event) == -1)
+    throw std::runtime_error("event register failed");
+}
+
+void Service::SetReadEvent(int const epoll_fd, int const target_fd) {
+  struct epoll_event event;
+
+  event.events = EPOLLIN | EPOLLET | EPOLLONESHOT | EPOLLRDHUP;
+  event.data.fd = target_fd;
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_MOD, target_fd, &event) == -1)
+    throw std::runtime_error("event register failed");
+}
+
+}  // namespace Just1RCe

--- a/srcs/service/run_irc_server.cc
+++ b/srcs/service/run_irc_server.cc
@@ -1,0 +1,51 @@
+
+extern "C" {
+#include <sys/epoll.h>
+}
+
+#include <stdexcept>
+#include <string>
+
+#include "../../includes/command_handler.h"
+#include "../../includes/service.h"
+#include "../../includes/tcp_socket.h"
+
+namespace Just1RCe {
+
+/**
+ *
+ * @brief service routine of the irc server
+ * @warning because of using epoll, it works only on Linux
+ * @param port_number port number in string, to make server socket
+ * @param cmd_map map command string to command handler
+ *
+ */
+void Service::RunIrcServer(std::string const &port_number,
+                           CommandMapping const &cmd_map) {
+  // get kernel event queue, epoll
+  int const epoll_fd = epoll_create1(0);
+  if (epoll_fd == -1) throw std::runtime_error("epoll creation failed");
+  struct epoll_event event_buffer[JUST1RCE_SRCS_EVENT_BUFFER_SIZE];
+
+  // get server socket(listening socket)
+  TcpSocket server(port_number);
+  RegisterServer(epoll_fd, server.socket_fd());
+
+  while (true) {
+    // get events from event queue
+    int const recv_event_cnt =
+        epoll_wait(epoll_fd, event_buffer, JUST1RCE_SRCS_EVENT_BUFFER_SIZE, -1);
+    if (recv_event_cnt == -1) throw std::runtime_error("epoll_wait failed");
+
+    // handling events
+    for (int i = 0; i < recv_event_cnt; ++i) {
+      if (event_buffer[i].data.fd == server.socket_fd()) {
+        HandleServerEvent(epoll_fd, cmd_map, event_buffer[i]);
+      } else {
+        HandleClientEvent(epoll_fd, cmd_map, event_buffer[i]);
+      }
+    }
+  }
+}
+
+}  // namespace Just1RCe


### PR DESCRIPTION
# Service routine 구현 \#37 
## Overview
epoll에 기반한 서비스 루틴 구현.

해당 루틴은 다음의 세 부분으로 구성됨.

- event utility : epoll_event를 활용하여 kernel queue에 이벤트를 등록 및 조작하는 함수들, 내부에서만 사용됨
- event handler : client 혹은 server를 대상으로 발생한 이벤트를 실제로 처리하는 함수들, 내부에서만 사용됨
- RunIrcServer : 실제 service routine, epoll을 기반으로 동작함.

## PR Type
어떤 변경 사항이 있나요?

- [x] feat

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
