### PR TITLE
#101 feat numeric에 따른 response 형식을 만드는 response generator 추가

### DIFF
--- a/includes/response_generator.h
+++ b/includes/response_generator.h
@@ -12,30 +12,33 @@ class Channel;
 namespace Just1RCe {
 
 struct ResponseArguments {
-  std::string client_name;   // %c, 클라이언트 이름
-  std::string channel_name;  // %h, 채널 (optional)
-  std::string nicknames;     // %n, 닉네임 목록 (optional)
-  std::string topic;         // %t, 채널 주제 ((optional))
-  std::string command_name;  // %d, 명령어
-  std::string modstring;     // %m, 모드 문자열 (optional)
+  std::string client_name;          // %c, 클라이언트 이름
+  std::string channel_name;         // %h, 채널 (optional)
+  std::string nicknames;            // %n, 닉네임 (optional)
+  std::string topic;                // %t, 채널 주제 (optional)
+  std::string modstring;            // %m, 모드 문자열 (optional)
+  std::vector<std::string> params;  // %p, 파라미터 목록
 
-  ResponseArguments(const Client& client, const Channel& channel,
-                    const std::vector<Client*>& client_list,
-                    const std::string& command);
+  ResponseArguments(const int numeric, const Client& client,
+                    const Channel* channel, std::vector<std::string> params);
 };
 
 class ResponseGenerator {
  private:
-  static const char* response_templates_[JUST1RCE_MAX_NUMERIC];
+  static ResponseGenerator* instance_;
+  const char* response_templates_[JUST1RCE_MAX_NUMERIC];
 
+  ResponseGenerator();
   ResponseGenerator(const ResponseGenerator&);
   ResponseGenerator& operator=(const ResponseGenerator&);
+  void InitializeTemplates();
 
  public:
-  ResponseGenerator();
+  static ResponseGenerator* GetInstance();
+  static void DestroyInstance();
   ~ResponseGenerator();
-  std::string generate_response(const int numeric,
-                                const struct ResponseArguments& res_args);
+  std::string GenerateResponse(const int numeric,
+                               const struct ResponseArguments& res_args);
 };
 
 }  // namespace Just1RCe

--- a/includes/response_generator.h
+++ b/includes/response_generator.h
@@ -7,12 +7,14 @@
 class Client;
 class Channel;
 
+#define JUST1RCE_MAX_NUMERIC 1000
+
 namespace Just1RCe {
 
 struct ResponseArguments {
   std::string client_name;   // %c, 클라이언트 이름
-  std::string nicknames;     // %n, 닉네임 목록 (optional)
   std::string channel_name;  // %h, 채널 (optional)
+  std::string nicknames;     // %n, 닉네임 목록 (optional)
   std::string topic;         // %t, 채널 주제 ((optional))
   std::string command_name;  // %d, 명령어
   std::string modstring;     // %m, 모드 문자열 (optional)
@@ -24,7 +26,10 @@ struct ResponseArguments {
 
 class ResponseGenerator {
  private:
-  static const char* response_templates_[1000];
+  static const char* response_templates_[JUST1RCE_MAX_NUMERIC];
+
+  ResponseGenerator(const ResponseGenerator&);
+  ResponseGenerator& operator=(const ResponseGenerator&);
 
  public:
   ResponseGenerator();

--- a/includes/response_generator.h
+++ b/includes/response_generator.h
@@ -16,16 +16,17 @@ struct ResponseArguments {
   std::string channel_name;         // %h, 채널 (optional)
   std::string nicknames;            // %n, 닉네임 (optional)
   std::string topic;                // %t, 채널 주제 (optional)
-  std::string modstring;            // %m, 모드 문자열 (optional)
+  std::string modestring;           // %m, 모드 문자열 (optional)
+  std::string command_name;         // %C, 명령어 이름
   std::vector<std::string> params;  // %p, 파라미터 목록
 
   ResponseArguments(const int numeric, const Client& client,
-                    const Channel* channel, const std::vector<std::string>& params);
+                    const Channel* channel,
+                    const std::vector<std::string>& params);
 };
 
 class ResponseGenerator {
  private:
-  static ResponseGenerator* instance_;
   const char* response_templates_[JUST1RCE_MAX_NUMERIC];
 
   ResponseGenerator();
@@ -34,8 +35,7 @@ class ResponseGenerator {
   void InitializeTemplates();
 
  public:
-  static ResponseGenerator* GetInstance();
-  static void DestroyInstance();
+  static ResponseGenerator& GetInstance();
   ~ResponseGenerator();
   std::string GenerateResponse(const int numeric,
                                const struct ResponseArguments& res_args);

--- a/includes/response_generator.h
+++ b/includes/response_generator.h
@@ -20,7 +20,7 @@ struct ResponseArguments {
   std::vector<std::string> params;  // %p, 파라미터 목록
 
   ResponseArguments(const int numeric, const Client& client,
-                    const Channel* channel, std::vector<std::string> params);
+                    const Channel* channel, std::vector<std::string>& params);
 };
 
 class ResponseGenerator {

--- a/includes/response_generator.h
+++ b/includes/response_generator.h
@@ -20,7 +20,7 @@ struct ResponseArguments {
   std::vector<std::string> params;  // %p, 파라미터 목록
 
   ResponseArguments(const int numeric, const Client& client,
-                    const Channel* channel, std::vector<std::string>& params);
+                    const Channel* channel, const std::vector<std::string>& params);
 };
 
 class ResponseGenerator {

--- a/includes/response_generator.h
+++ b/includes/response_generator.h
@@ -1,0 +1,38 @@
+#ifndef JUST1RCE_SRCS_RESPONSE_GENERATOR_H_
+#define JUST1RCE_SRCS_RESPONSE_GENERATOR_H_
+
+#include <string>
+#include <vector>
+
+class Client;
+class Channel;
+
+namespace Just1RCe {
+
+struct ResponseArguments {
+  std::string client_name;   // %c, 클라이언트 이름
+  std::string nicknames;     // %n, 닉네임 목록 (optional)
+  std::string channel_name;  // %h, 채널 (optional)
+  std::string topic;         // %t, 채널 주제 ((optional))
+  std::string command_name;  // %d, 명령어
+  std::string modstring;     // %m, 모드 문자열 (optional)
+
+  ResponseArguments(const Client& client, const Channel& channel,
+                    const std::vector<Client*>& client_list,
+                    const std::string& command);
+};
+
+class ResponseGenerator {
+ private:
+  static const char* response_templates_[1000];
+
+ public:
+  ResponseGenerator();
+  ~ResponseGenerator();
+  std::string generate_response(const int numeric,
+                                const struct ResponseArguments& res_args);
+};
+
+}  // namespace Just1RCe
+
+#endif  // JUST1RCE_SRCS_RESPONSE_GENERATOR_H_

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -10,7 +10,7 @@
 #include "../../includes/dbcontext.h"
 #include "../../includes/numeric.h"
 
-static void GenerateNicknames(std::vector<Client*> client_list,
+static void GenerateNicknames(std::vector<Client*>& client_list,
                               std::string* nicknames);
 
 namespace Just1RCe {
@@ -42,7 +42,7 @@ ResponseArguments::ResponseArguments(const int numeric, const Client& client,
   command_name = params[0];
 
   if (numeric == RPL_NAMREPLY && channel != NULL) {
-    generate_nicknames(
+    GenerateNicknames(
         ContextHolder().GetInstance()->db()->GetClientsByChannelName(
             channel->name()),
         &nicknames);
@@ -71,7 +71,7 @@ void ResponseGenerator::DestroyInstance() {
   }
 }
 
-ResponseGenerator::ResponseGenerator() { initialize_templates(); }
+ResponseGenerator::ResponseGenerator() { InitializeTemplates(); }
 
 ResponseGenerator::~ResponseGenerator() {}
 

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -1,0 +1,148 @@
+#include "../../response_generator.h"
+
+#include <string>
+#include <vector>
+
+#include "../../config.h"
+#include "../../includes/Client.h"
+#include "../../includes/channel.h"
+#include "../../includes/numeric.h"
+
+namespace Just1RCe {
+
+/**
+ * @brief Construct a new Response Arguments:: Response Arguments object
+ *
+ * @param client: client object
+ * @param channel: channel object
+ * @param client_list: list of client objects
+ * @param command: command string
+ *
+ * @return ResponseArguments
+ *
+ * @note This constructor is used to generate response arguments for the
+ * response generator
+ */
+ResponseArguments::ResponseArguments(const Client& client,
+                                     const Channel& channel,
+                                     const std::vector<Client*>& client_list,
+                                     const std::string& command) {
+  client_name = client.nick_name();
+  channel_name = channel.name();
+  topic = channel.topic();
+  command_name = command;
+  modestirng = channel.GetModeAsString();
+
+  for (size_t i = 0; i < client_list->size(); i++) {
+    if (i != 0) {
+      nicknames += JUST1RCE_SPACE;
+    }
+    nicknames += client_list[i]->nick_name();
+  }
+}
+
+ResponseGenerator::ResponseGenerator() {
+  response_templates_[RPL_WELCOME] =
+      ":%s 001 %c :Welcome to the SHELLDIVERS Network, %n";
+  response_templates_[RPL_YOURHOST] =
+      ":%s 002 %c :Your host is %s, running version %v";
+  response_templates_[RPL_CHANNELMODEIS] = ":%s 324 %c %h %m";
+  response_templates_[RPL_NOTOPIC] = ":%s 331 %c %h :No topic is set";
+  response_templates_[RPL_TOPIC] = ":%s 332 %c %h :%t";
+  response_templates_[RPL_INVITING] = ":%s 341 %c %n %h";
+  response_templates_[RPL_NAMREPLY] = ":%s 353 %c = %h :%n{ %n}";
+  response_templates_[RPL_ENDOFNAMES] = ":%s 366 %c %h :End of /NAMES list";
+  response_templates_[ERR_NOSUCHNICK] =
+      ":%s 401 %c <nickname> :No such nick/channel";
+  response_templates_[ERR_NOSUCHCHANNEL] = ":%s 403 %c %h :No such channel";
+  response_templates_[ERR_CANNOTSENDTOCHAN] =
+      ":%s 404 %c %h :Cannot send to channel";
+  response_templates_[ERR_TOOMANYCHANNELS] =
+      ":%s 405 %c %h :You have joined too many channels";
+  response_templates_[ERR_NOORIGIN] = ":%s 409 %c :No origin specified";
+  response_templates_[ERR_NORECIPIENT] = ":%s 411 %c :No recipient given (%d)";
+  response_templates_[ERR_NOTEXTTOSEND] = ":%s 412 %c :No text to send";
+  response_templates_[ERR_NONICKNAMEGIVEN] = ":%s 431 %c :No nickname given";
+  response_templates_[ERR_ERRONEUSNICKNAME] =
+      ":%s 432 %c %n :Erroneus nickname";
+  response_templates_[ERR_NICKNAMEINUSE] =
+      ":%s 433 %c %n :Nickname is already in use";
+  response_templates_[ERR_USERNOTINCHANNEL] =
+      ":%s 441 %c %n %h :They aren't on that channel";
+  response_templates_[ERR_NOTONCHANNEL] =
+      ":%s 442 %c %h :You're not on that channel";
+  response_templates_[ERR_USERONCHANNEL] =
+      ":%s 443 %c %n %h :is already on channel";
+  response_templates_[ERR_NOTREGISTERED] =
+      ":%s 451 %c :You have not registered";
+  response_templates_[ERR_NEEDMOREPARAMS] =
+      ":%s 461 %c %d :Not enough parameters";
+  response_templates_[ERR_ALREADYREGISTERED] =
+      ":%s 462 %c :You may not reregister";
+  response_templates_[ERR_CHANNELISFULL] =
+      ":%s 471 %c %h :Cannot join channel (+l)";
+  response_templates_[ERR_INVITEONLYCHAN] =
+      ":%s 473 %c %h :Cannot join channel (+i)";
+  response_templates_[ERR_BADCHANNELKEY] =
+      ":%s 475 %c %h :Cannot join channel (+k)";
+  response_templates_[ERR_BADCHANMASK] = ":%s 476 %h :Bad Channel Mask";
+  response_templates_[ERR_CHANOPRIVSNEEDED] =
+      ":%s 482 %c %h :You're not channel operator";
+}
+
+ResponseGenerator::~ResponseGenerator() {}
+
+/**
+ * @brief Generate response message
+ *
+ * @param numeric: numeric code
+ * @param reg_args: response arguments
+ *
+ * @return std::string
+ *
+ * @note This function generates response message based on the numeric code and
+ * response arguments
+ */
+std::string ResponseGenerator::generate_response(
+    const int numeric, const struct ResponseArguments& reg_args) {
+  std::string response_template = response_templates_[numeric];
+  std::string response = "";
+
+  for (size_t i = 0; i < response_template.size(); ++i) {
+    if (response_template[i] == '%') {
+      switch (response_template[++i]) {
+        case 'c':
+          response += reg_args.client_name;
+          break;
+        case 'n':
+          response += reg_args.nicknames;
+          break;
+        case 'h':
+          response += reg_args.channel_name;
+          break;
+        case 't':
+          response += reg_args.topic;
+          break;
+        case 'd':
+          response += reg_args.command_name;
+          break;
+        case 'm':
+          response += reg_args.modestring;
+          break;
+        case 'v':
+          response += JUST1RCE_VERSION;
+          break;
+        case 's':
+          response += JUST1RCE_SERVER_NAME;
+          break;
+      }
+      i++;
+    } else {
+      response += response_template[i];
+    }
+  }
+
+  return response;
+}
+
+}  // namespace Just1RCe

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -36,7 +36,7 @@ ResponseArguments::ResponseArguments(const int numeric, const Client& client,
   if (channel != NULL) {
     channel_name = channel.name();
     topic = channel.topic();
-    modestirng = channel.GetModeAsString();
+    modestring = channel.GetModeAsString();
   }
   client_name = client.nick_name();
   command_name = params[0];
@@ -53,22 +53,10 @@ ResponseArguments::ResponseArguments(const int numeric, const Client& client,
 
 /*----------------------ResponseGenerator--------------------------*/
 
-ResponseGenerator* ResponseGenerator::instance_ = NULL;
-const char* response_templates_[JUST1RCE_MAX_NUMERIC] = {};
-
-ResponseGenerator* ResponseGenerator::GetInstance() {
-  if (instance_ == NULL) {
-    instance_ = new ResponseGenerator();
-  }
+ResponseGenerator& ResponseGenerator::GetInstance() {
+  static ResponseGenerator instance_;
 
   return instance_;
-}
-
-void ResponseGenerator::DestroyInstance() {
-  if (instance_ != NULL) {
-    delete instance_;
-    instance_ = NULL;
-  }
 }
 
 ResponseGenerator::ResponseGenerator() { InitializeTemplates(); }
@@ -94,7 +82,7 @@ void ResponseGenerator::InitializeTemplates() {
   response_templates_[ERR_TOOMANYCHANNELS] =
       ":%s 405 %c %h :You have joined too many channels";
   response_templates_[ERR_NOORIGIN] = ":%s 409 %c :No origin specified";
-  response_templates_[ERR_NORECIPIENT] = ":%s 411 %c :No recipient given (%d)";
+  response_templates_[ERR_NORECIPIENT] = ":%s 411 %c :No recipient given (%C)";
   response_templates_[ERR_NOTEXTTOSEND] = ":%s 412 %c :No text to send";
   response_templates_[ERR_NONICKNAMEGIVEN] = ":%s 431 %c :No nickname given";
   response_templates_[ERR_ERRONEUSNICKNAME] =
@@ -110,7 +98,7 @@ void ResponseGenerator::InitializeTemplates() {
   response_templates_[ERR_NOTREGISTERED] =
       ":%s 451 %c :You have not registered";
   response_templates_[ERR_NEEDMOREPARAMS] =
-      ":%s 461 %c %d :Not enough parameters";
+      ":%s 461 %c %C :Not enough parameters";
   response_templates_[ERR_ALREADYREGISTERED] =
       ":%s 462 %c :You may not reregister";
   response_templates_[ERR_CHANNELISFULL] =
@@ -155,11 +143,11 @@ std::string ResponseGenerator::GenerateResponse(
         case 't':
           response += reg_args.topic;
           break;
-        case 'd':
+        case 'C':
           response += reg_args.command_name;
           break;
         case 'm':
-          response += reg_args.modstring;
+          response += reg_args.modestring;
           break;
         case 'v':
           response += JUST1RCE_VERSION;

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -136,7 +136,6 @@ std::string ResponseGenerator::generate_response(
           response += JUST1RCE_SERVER_NAME;
           break;
       }
-      i++;
     } else {
       response += response_template[i];
     }

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -10,7 +10,7 @@
 #include "../../includes/dbcontext.h"
 #include "../../includes/numeric.h"
 
-static void GenerateNicknames(std::vector<Client*>& client_list,
+static void GenerateNicknames(const std::vector<Client*>& client_list,
                               std::string* nicknames);
 
 namespace Just1RCe {

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -74,9 +74,9 @@ ResponseArguments::ResponseArguments(const Client& client,
 }
 
 ResponseGenerator::ResponseGenerator() {
-  static bool initialized = false;
+  static bool response_templates_initialized = false;
 
-  if (initialized == false) {
+  if (response_templates_initialized == false) {
     response_templates_[RPL_WELCOME] =
         ":%s 001 %c :Welcome to the SHELLDIVERS Network, %c";
     response_templates_[RPL_YOURHOST] =
@@ -135,7 +135,7 @@ ResponseGenerator::ResponseGenerator() {
     response_templates_[ERR_CHANOPRIVSNEEDED] =
         ":%s 482 %c %h :You're not channel operator";
 
-    initialized = true;
+	response_templates_initialized = true;
   }
 }
 

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -6,140 +6,123 @@
 #include "../../config.h"
 #include "../../includes/Client.h"
 #include "../../includes/channel.h"
+#include "../../includes/context_holder.h"
+#include "../../includes/dbcontext.h"
 #include "../../includes/numeric.h"
+
+static void GenerateNicknames(std::vector<Client*> client_list,
+                              std::string* nicknames);
 
 namespace Just1RCe {
 
-const char* ResponseGenerator::response_templates_[] = {
-    ":%s 001 %c :Welcome to the SHELLDIVERS Network, %n",
-    ":%s 002 %c :Your host is %s, running version %v",
-    ":%s 324 %c %h %m",
-    ":%s 331 %c %h :No topic is set",
-    ":%s 332 %c %h :%t",
-    ":%s 341 %c %n %h",
-    ":%s 353 %c = %h :%n{ %n}",
-    ":%s 366 %c %h :End of /NAMES list",
-    ":%s 401 %c <nickname> :No such nick/channel",
-    ":%s 403 %c %h :No such channel",
-    ":%s 404 %c %h :Cannot send to channel",
-    ":%s 405 %c %h :You have joined too many channels",
-    ":%s 409 %c :No origin specified",
-    ":%s 411 %c :No recipient given (%d)",
-    ":%s 412 %c :No text to send",
-    ":%s 431 %c :No nickname given",
-    ":%s 432 %c %n :Erroneus nickname",
-    ":%s 433 %c %n :Nickname is already in use",
-    ":%s 441 %c %n %h :They aren't on that channel",
-    ":%s 442 %c %h :You're not on that channel",
-    ":%s 443 %c %n %h :is already on channel",
-    ":%s 451 %c :You have not registered",
-    ":%s 461 %c %d :Not enough parameters",
-    ":%s 462 %c :You may not reregister",
-    ":%s 471 %c %h :Cannot join channel (+l)",
-    ":%s 473 %c %h :Cannot join channel (+i)",
-    ":%s 475 %c %h :Cannot join channel (+k)",
-    ":%s 476 %h :Bad Channel Mask",
-    ":%s 482 %c %h :You're not channel operator",
-};
+/*----------------------ResponseArguments--------------------------*/
 
 /**
  * @brief Construct a new Response Arguments:: Response Arguments object
  *
+ * @param numeric: numeric code
  * @param client: client object
  * @param channel: channel object
- * @param client_list: list of client objects
- * @param command: command string
+ * @param params: vector of string
  *
  * @return ResponseArguments
  *
  * @note This constructor is used to generate response arguments for the
  * response generator
  */
-ResponseArguments::ResponseArguments(const Client& client,
-                                     const Channel& channel,
-                                     const std::vector<Client*>& client_list,
-                                     const std::string& command) {
+ResponseArguments::ResponseArguments(const int numeric, const Client& client,
+                                     const Channel* channel,
+                                     const std::vector<std::string>& params) {
+  if (channel != NULL) {
+    channel_name = channel.name();
+    topic = channel.topic();
+    modestirng = channel.GetModeAsString();
+  }
   client_name = client.nick_name();
-  channel_name = channel.name();
-  topic = channel.topic();
-  command_name = command;
-  modestirng = channel.GetModeAsString();
+  command_name = params[0];
 
-  for (size_t i = 0; i < client_list->size(); i++) {
-    if (i != 0) {
-      nicknames += JUST1RCE_SPACE;
-    }
-    nicknames += client_list[i]->nick_name();
+  if (numeric == RPL_NAMREPLY && channel != NULL) {
+    generate_nicknames(
+        ContextHolder().GetInstance()->db()->GetClientsByChannelName(
+            channel->name()),
+        &nicknames);
+  } else {
+    nicknames = params[1];
   }
 }
 
-ResponseGenerator::ResponseGenerator() {
-  static bool response_templates_initialized = false;
+/*----------------------ResponseGenerator--------------------------*/
 
-  if (response_templates_initialized == false) {
-    response_templates_[RPL_WELCOME] =
-        ":%s 001 %c :Welcome to the SHELLDIVERS Network, %c";
-    response_templates_[RPL_YOURHOST] =
-        ":%s 002 %c :Your host is %s, running version %v";
-    response_templates_[RPL_CHANNELMODEIS] = 
-	    ":%s 324 %c %h %m";
-    response_templates_[RPL_NOTOPIC] = 
-	    ":%s 331 %c %h :No topic is set";
-    response_templates_[RPL_TOPIC] = 
-	    ":%s 332 %c %h :%t";
-    response_templates_[RPL_INVITING] = 
-	    ":%s 341 %c %n %h"; // Need to check
-    response_templates_[RPL_NAMREPLY] = 
-	    ":%s 353 %c = %h :%n{ %n}"; // Need to check
-    response_templates_[RPL_ENDOFNAMES] = 
-	    ":%s 366 %c %h :End of /NAMES list";
-    response_templates_[ERR_NOSUCHNICK] =
-        ":%s 401 %c <nickname> :No such nick/channel";
-    response_templates_[ERR_NOSUCHCHANNEL] = ":%s 403 %c %h :No such channel";
-    response_templates_[ERR_CANNOTSENDTOCHAN] =
-        ":%s 404 %c %h :Cannot send to channel";
-    response_templates_[ERR_TOOMANYCHANNELS] =
-        ":%s 405 %c %h :You have joined too many channels";
-    response_templates_[ERR_NOORIGIN] = 
-	    ":%s 409 %c :No origin specified";
-    response_templates_[ERR_NORECIPIENT] =
-        ":%s 411 %c :No recipient given (%d)";
-    response_templates_[ERR_NOTEXTTOSEND] = 
-	    ":%s 412 %c :No text to send";
-    response_templates_[ERR_NONICKNAMEGIVEN] = 
-	    ":%s 431 %c :No nickname given";
-    response_templates_[ERR_ERRONEUSNICKNAME] =
-        ":%s 432 %c %n :Erroneus nickname"; // Need to check
-    response_templates_[ERR_NICKNAMEINUSE] =
-        ":%s 433 %c %n :Nickname is already in use"; // Need to check
-    response_templates_[ERR_USERNOTINCHANNEL] =
-        ":%s 441 %c %n %h :They aren't on that channel"; // Need to check
-    response_templates_[ERR_NOTONCHANNEL] =
-        ":%s 442 %c %h :You're not on that channel";
-    response_templates_[ERR_USERONCHANNEL] =
-        ":%s 443 %c %n %h :is already on channel"; // Need to check
-    response_templates_[ERR_NOTREGISTERED] =
-        ":%s 451 %c :You have not registered";
-    response_templates_[ERR_NEEDMOREPARAMS] =
-        ":%s 461 %c %d :Not enough parameters";
-    response_templates_[ERR_ALREADYREGISTERED] =
-        ":%s 462 %c :You may not reregister";
-    response_templates_[ERR_CHANNELISFULL] =
-        ":%s 471 %c %h :Cannot join channel (+l)";
-    response_templates_[ERR_INVITEONLYCHAN] =
-        ":%s 473 %c %h :Cannot join channel (+i)";
-    response_templates_[ERR_BADCHANNELKEY] =
-        ":%s 475 %c %h :Cannot join channel (+k)";
-    response_templates_[ERR_BADCHANMASK] = 
-	    ":%s 476 %h :Bad Channel Mask";
-    response_templates_[ERR_CHANOPRIVSNEEDED] =
-        ":%s 482 %c %h :You're not channel operator";
+ResponseGenerator* ResponseGenerator::instance_ = NULL;
+const char* response_templates_[JUST1RCE_MAX_NUMERIC] = {};
 
-	response_templates_initialized = true;
+ResponseGenerator* ResponseGenerator::GetInstance() {
+  if (instance_ == NULL) {
+    instance_ = new ResponseGenerator();
+  }
+
+  return instance_;
+}
+
+void ResponseGenerator::DestroyInstance() {
+  if (instance_ != NULL) {
+    delete instance_;
+    instance_ = NULL;
   }
 }
+
+ResponseGenerator::ResponseGenerator() { initialize_templates(); }
 
 ResponseGenerator::~ResponseGenerator() {}
+
+void ResponseGenerator::InitializeTemplates() {
+  response_templates_[RPL_WELCOME] =
+      ":%s 001 %c :Welcome to the SHELLDIVERS Network, %c";
+  response_templates_[RPL_YOURHOST] =
+      ":%s 002 %c :Your host is %s, running version %v";
+  response_templates_[RPL_CHANNELMODEIS] = ":%s 324 %c %h %m";
+  response_templates_[RPL_NOTOPIC] = ":%s 331 %c %h :No topic is set";
+  response_templates_[RPL_TOPIC] = ":%s 332 %c %h :%t";
+  response_templates_[RPL_INVITING] = ":%s 341 %c %n %h";
+  response_templates_[RPL_NAMREPLY] = ":%s 353 %c = %h :%n";
+  response_templates_[RPL_ENDOFNAMES] = ":%s 366 %c %h :End of /NAMES list";
+  response_templates_[ERR_NOSUCHNICK] =
+      ":%s 401 %c <nickname> :No such nick/channel";
+  response_templates_[ERR_NOSUCHCHANNEL] = ":%s 403 %c %h :No such channel";
+  response_templates_[ERR_CANNOTSENDTOCHAN] =
+      ":%s 404 %c %h :Cannot send to channel";
+  response_templates_[ERR_TOOMANYCHANNELS] =
+      ":%s 405 %c %h :You have joined too many channels";
+  response_templates_[ERR_NOORIGIN] = ":%s 409 %c :No origin specified";
+  response_templates_[ERR_NORECIPIENT] = ":%s 411 %c :No recipient given (%d)";
+  response_templates_[ERR_NOTEXTTOSEND] = ":%s 412 %c :No text to send";
+  response_templates_[ERR_NONICKNAMEGIVEN] = ":%s 431 %c :No nickname given";
+  response_templates_[ERR_ERRONEUSNICKNAME] =
+      ":%s 432 %c %n :Erroneus nickname";
+  response_templates_[ERR_NICKNAMEINUSE] =
+      ":%s 433 %c %n :Nickname is already in use";
+  response_templates_[ERR_USERNOTINCHANNEL] =
+      ":%s 441 %c %n %h :They aren't on that channel";
+  response_templates_[ERR_NOTONCHANNEL] =
+      ":%s 442 %c %h :You're not on that channel";
+  response_templates_[ERR_USERONCHANNEL] =
+      ":%s 443 %c %n %h :is already on channel";
+  response_templates_[ERR_NOTREGISTERED] =
+      ":%s 451 %c :You have not registered";
+  response_templates_[ERR_NEEDMOREPARAMS] =
+      ":%s 461 %c %d :Not enough parameters";
+  response_templates_[ERR_ALREADYREGISTERED] =
+      ":%s 462 %c :You may not reregister";
+  response_templates_[ERR_CHANNELISFULL] =
+      ":%s 471 %c %h :Cannot join channel (+l)";
+  response_templates_[ERR_INVITEONLYCHAN] =
+      ":%s 473 %c %h :Cannot join channel (+i)";
+  response_templates_[ERR_BADCHANNELKEY] =
+      ":%s 475 %c %h :Cannot join channel (+k)";
+  response_templates_[ERR_BADCHANMASK] = ":%s 476 %h :Bad Channel Mask";
+  response_templates_[ERR_CHANOPRIVSNEEDED] =
+      ":%s 482 %c %h :You're not channel operator";
+}
 
 /**
  * @brief Generate response message
@@ -149,10 +132,10 @@ ResponseGenerator::~ResponseGenerator() {}
  *
  * @return std::string
  *
- * @note This function generates response message based on the numeric code and
- * response arguments
+ * @note This function generates response message based on the numeric code
+ * and response arguments
  */
-std::string ResponseGenerator::generate_response(
+std::string ResponseGenerator::GenerateResponse(
     const int numeric, const struct ResponseArguments& reg_args) {
   std::string response_template = response_templates_[numeric];
   std::string response = "";
@@ -176,7 +159,7 @@ std::string ResponseGenerator::generate_response(
           response += reg_args.command_name;
           break;
         case 'm':
-          response += reg_args.modestring;
+          response += reg_args.modstring;
           break;
         case 'v':
           response += JUST1RCE_VERSION;
@@ -194,3 +177,15 @@ std::string ResponseGenerator::generate_response(
 }
 
 }  // namespace Just1RCe
+
+static void GenerateNicknames(const std::vector<Client*> &client_list,
+                              std::string* nicknames) {
+  *nicknames = "";
+
+  for (size_t i = 0; i < client_list.size(); i++) {
+    if (i != 0) {
+      *nicknames += " ";
+    }
+    *nicknames += client_list[i]->nick_name();
+  }
+}

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -32,7 +32,7 @@ namespace Just1RCe {
  */
 ResponseArguments::ResponseArguments(const int numeric, const Client& client,
                                      const Channel* channel,
-                                     std::vector<std::string>& params) {
+                                     const std::vector<std::string>& params) {
   if (channel != NULL) {
     channel_name = channel.name();
     topic = channel.topic();

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -10,6 +10,38 @@
 
 namespace Just1RCe {
 
+const char* ResponseGenerator::response_templates_[] = {
+    ":%s 001 %c :Welcome to the SHELLDIVERS Network, %n",
+    ":%s 002 %c :Your host is %s, running version %v",
+    ":%s 324 %c %h %m",
+    ":%s 331 %c %h :No topic is set",
+    ":%s 332 %c %h :%t",
+    ":%s 341 %c %n %h",
+    ":%s 353 %c = %h :%n{ %n}",
+    ":%s 366 %c %h :End of /NAMES list",
+    ":%s 401 %c <nickname> :No such nick/channel",
+    ":%s 403 %c %h :No such channel",
+    ":%s 404 %c %h :Cannot send to channel",
+    ":%s 405 %c %h :You have joined too many channels",
+    ":%s 409 %c :No origin specified",
+    ":%s 411 %c :No recipient given (%d)",
+    ":%s 412 %c :No text to send",
+    ":%s 431 %c :No nickname given",
+    ":%s 432 %c %n :Erroneus nickname",
+    ":%s 433 %c %n :Nickname is already in use",
+    ":%s 441 %c %n %h :They aren't on that channel",
+    ":%s 442 %c %h :You're not on that channel",
+    ":%s 443 %c %n %h :is already on channel",
+    ":%s 451 %c :You have not registered",
+    ":%s 461 %c %d :Not enough parameters",
+    ":%s 462 %c :You may not reregister",
+    ":%s 471 %c %h :Cannot join channel (+l)",
+    ":%s 473 %c %h :Cannot join channel (+i)",
+    ":%s 475 %c %h :Cannot join channel (+k)",
+    ":%s 476 %h :Bad Channel Mask",
+    ":%s 482 %c %h :You're not channel operator",
+};
+
 /**
  * @brief Construct a new Response Arguments:: Response Arguments object
  *
@@ -42,52 +74,69 @@ ResponseArguments::ResponseArguments(const Client& client,
 }
 
 ResponseGenerator::ResponseGenerator() {
-  response_templates_[RPL_WELCOME] =
-      ":%s 001 %c :Welcome to the SHELLDIVERS Network, %n";
-  response_templates_[RPL_YOURHOST] =
-      ":%s 002 %c :Your host is %s, running version %v";
-  response_templates_[RPL_CHANNELMODEIS] = ":%s 324 %c %h %m";
-  response_templates_[RPL_NOTOPIC] = ":%s 331 %c %h :No topic is set";
-  response_templates_[RPL_TOPIC] = ":%s 332 %c %h :%t";
-  response_templates_[RPL_INVITING] = ":%s 341 %c %n %h";
-  response_templates_[RPL_NAMREPLY] = ":%s 353 %c = %h :%n{ %n}";
-  response_templates_[RPL_ENDOFNAMES] = ":%s 366 %c %h :End of /NAMES list";
-  response_templates_[ERR_NOSUCHNICK] =
-      ":%s 401 %c <nickname> :No such nick/channel";
-  response_templates_[ERR_NOSUCHCHANNEL] = ":%s 403 %c %h :No such channel";
-  response_templates_[ERR_CANNOTSENDTOCHAN] =
-      ":%s 404 %c %h :Cannot send to channel";
-  response_templates_[ERR_TOOMANYCHANNELS] =
-      ":%s 405 %c %h :You have joined too many channels";
-  response_templates_[ERR_NOORIGIN] = ":%s 409 %c :No origin specified";
-  response_templates_[ERR_NORECIPIENT] = ":%s 411 %c :No recipient given (%d)";
-  response_templates_[ERR_NOTEXTTOSEND] = ":%s 412 %c :No text to send";
-  response_templates_[ERR_NONICKNAMEGIVEN] = ":%s 431 %c :No nickname given";
-  response_templates_[ERR_ERRONEUSNICKNAME] =
-      ":%s 432 %c %n :Erroneus nickname";
-  response_templates_[ERR_NICKNAMEINUSE] =
-      ":%s 433 %c %n :Nickname is already in use";
-  response_templates_[ERR_USERNOTINCHANNEL] =
-      ":%s 441 %c %n %h :They aren't on that channel";
-  response_templates_[ERR_NOTONCHANNEL] =
-      ":%s 442 %c %h :You're not on that channel";
-  response_templates_[ERR_USERONCHANNEL] =
-      ":%s 443 %c %n %h :is already on channel";
-  response_templates_[ERR_NOTREGISTERED] =
-      ":%s 451 %c :You have not registered";
-  response_templates_[ERR_NEEDMOREPARAMS] =
-      ":%s 461 %c %d :Not enough parameters";
-  response_templates_[ERR_ALREADYREGISTERED] =
-      ":%s 462 %c :You may not reregister";
-  response_templates_[ERR_CHANNELISFULL] =
-      ":%s 471 %c %h :Cannot join channel (+l)";
-  response_templates_[ERR_INVITEONLYCHAN] =
-      ":%s 473 %c %h :Cannot join channel (+i)";
-  response_templates_[ERR_BADCHANNELKEY] =
-      ":%s 475 %c %h :Cannot join channel (+k)";
-  response_templates_[ERR_BADCHANMASK] = ":%s 476 %h :Bad Channel Mask";
-  response_templates_[ERR_CHANOPRIVSNEEDED] =
-      ":%s 482 %c %h :You're not channel operator";
+  static bool initialized = false;
+
+  if (initialized == false) {
+    response_templates_[RPL_WELCOME] =
+        ":%s 001 %c :Welcome to the SHELLDIVERS Network, %c";
+    response_templates_[RPL_YOURHOST] =
+        ":%s 002 %c :Your host is %s, running version %v";
+    response_templates_[RPL_CHANNELMODEIS] = 
+	    ":%s 324 %c %h %m";
+    response_templates_[RPL_NOTOPIC] = 
+	    ":%s 331 %c %h :No topic is set";
+    response_templates_[RPL_TOPIC] = 
+	    ":%s 332 %c %h :%t";
+    response_templates_[RPL_INVITING] = 
+	    ":%s 341 %c %n %h"; // Need to check
+    response_templates_[RPL_NAMREPLY] = 
+	    ":%s 353 %c = %h :%n{ %n}"; // Need to check
+    response_templates_[RPL_ENDOFNAMES] = 
+	    ":%s 366 %c %h :End of /NAMES list";
+    response_templates_[ERR_NOSUCHNICK] =
+        ":%s 401 %c <nickname> :No such nick/channel";
+    response_templates_[ERR_NOSUCHCHANNEL] = ":%s 403 %c %h :No such channel";
+    response_templates_[ERR_CANNOTSENDTOCHAN] =
+        ":%s 404 %c %h :Cannot send to channel";
+    response_templates_[ERR_TOOMANYCHANNELS] =
+        ":%s 405 %c %h :You have joined too many channels";
+    response_templates_[ERR_NOORIGIN] = 
+	    ":%s 409 %c :No origin specified";
+    response_templates_[ERR_NORECIPIENT] =
+        ":%s 411 %c :No recipient given (%d)";
+    response_templates_[ERR_NOTEXTTOSEND] = 
+	    ":%s 412 %c :No text to send";
+    response_templates_[ERR_NONICKNAMEGIVEN] = 
+	    ":%s 431 %c :No nickname given";
+    response_templates_[ERR_ERRONEUSNICKNAME] =
+        ":%s 432 %c %n :Erroneus nickname"; // Need to check
+    response_templates_[ERR_NICKNAMEINUSE] =
+        ":%s 433 %c %n :Nickname is already in use"; // Need to check
+    response_templates_[ERR_USERNOTINCHANNEL] =
+        ":%s 441 %c %n %h :They aren't on that channel"; // Need to check
+    response_templates_[ERR_NOTONCHANNEL] =
+        ":%s 442 %c %h :You're not on that channel";
+    response_templates_[ERR_USERONCHANNEL] =
+        ":%s 443 %c %n %h :is already on channel"; // Need to check
+    response_templates_[ERR_NOTREGISTERED] =
+        ":%s 451 %c :You have not registered";
+    response_templates_[ERR_NEEDMOREPARAMS] =
+        ":%s 461 %c %d :Not enough parameters";
+    response_templates_[ERR_ALREADYREGISTERED] =
+        ":%s 462 %c :You may not reregister";
+    response_templates_[ERR_CHANNELISFULL] =
+        ":%s 471 %c %h :Cannot join channel (+l)";
+    response_templates_[ERR_INVITEONLYCHAN] =
+        ":%s 473 %c %h :Cannot join channel (+i)";
+    response_templates_[ERR_BADCHANNELKEY] =
+        ":%s 475 %c %h :Cannot join channel (+k)";
+    response_templates_[ERR_BADCHANMASK] = 
+	    ":%s 476 %h :Bad Channel Mask";
+    response_templates_[ERR_CHANOPRIVSNEEDED] =
+        ":%s 482 %c %h :You're not channel operator";
+
+    initialized = true;
+  }
 }
 
 ResponseGenerator::~ResponseGenerator() {}

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -32,7 +32,7 @@ namespace Just1RCe {
  */
 ResponseArguments::ResponseArguments(const int numeric, const Client& client,
                                      const Channel* channel,
-                                     const std::vector<std::string>& params) {
+                                     std::vector<std::string>& params) {
   if (channel != NULL) {
     channel_name = channel.name();
     topic = channel.topic();
@@ -178,7 +178,7 @@ std::string ResponseGenerator::GenerateResponse(
 
 }  // namespace Just1RCe
 
-static void GenerateNicknames(const std::vector<Client*> &client_list,
+static void GenerateNicknames(const std::vector<Client*>& client_list,
                               std::string* nicknames) {
   *nicknames = "";
 


### PR DESCRIPTION
# numeric에 따른 response 형식을 만드는 response generator 추가 \#101
## Overview

Numeric 코드에 따른 메시지를 템플릿 형식으로 변환하여 std::string으로 반환하는 Response Generator 추가
IRC 응답 형식에 맞춰 클라이언트에게 전송할 메시지를 쉽게 생성할 수 있도록 함

## details

- 객체를 싱글톤으로 생성하여 불필요한 객체 생성을 회피하며
배열에대한 초기화도 한번만 실행하도록 구현하였음.
- 객체를 생성하였을시에 DestroyInstance()를 통해 제거 필요.



