### PR TITLE
134 feat channel에 operator 관련 내용 추가

### DIFF
--- a/includes/channel.h
+++ b/includes/channel.h
@@ -43,6 +43,7 @@ class Channel {
   std::string topic_;
   std::string key_;
   ChannelModeMask mod_;
+  int operator_fd_;
 
   // user info
   size_t max_user_num_;
@@ -79,6 +80,10 @@ class Channel {
 
   void IncreaseUserCount();
   void DecreaseUserCount();
+
+  // operator
+  int GetOperatorFd() const;
+  void operator_fd(int const new_operator_fd);
 
   // mod handler, authority check needed
   ChannelModeMask GetMode() const;

--- a/srcs/channel/channel.cc
+++ b/srcs/channel/channel.cc
@@ -66,4 +66,9 @@ size_t Channel::cur_user_count() const { return cur_user_count_; }
 void Channel::IncreaseUserCount() { ++cur_user_count_; }
 void Channel::DecreaseUserCount() { --cur_user_count_; }
 
+int Channel::GetOperatorFd() const { return operator_fd_; }
+void Channel::operator_fd(int const new_operator_fd) {
+  operator_fd_ = new_operator_fd;
+}
+
 }  // namespace Just1RCe

--- a/srcs/channel/channel.cc
+++ b/srcs/channel/channel.cc
@@ -21,6 +21,7 @@ Channel::Channel(std::string const &name, std::string const &key)
       topic_(""),
       key_(key),
       mod_(JUST1RCE_SRCS_CHANNEL_MOD_DEFAULT),
+      operator_fd_(-1),
       max_user_num_(std::numeric_limits<size_t>::max()),
       cur_user_count_(0) {
   // wrong channel name format error


### PR DESCRIPTION
#134 Channel에 operator추가
## Overview
채널에 소속된 사용자의 모드를 순회하며 operator권한을 찾는 것이 아닌, channel의 필드를 확인하여 즉시 식별할 수 있도록 한다.

## PR Type
어떤 변경 사항이 있나요?

- [x] feat

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
