### PR TITLE
#140 bug socket error handling

### DIFF
--- a/srcs/client/client_get_messages.cc
+++ b/srcs/client/client_get_messages.cc
@@ -28,7 +28,8 @@ static bool recv_and_append_buffer(int const fd, std::string *pbuffer) {
 
   memset(recv_buffer, '\0', JUST1RCE_SRCS_CLIENT_MSG_MAX + 1);
   while (true) {
-    recv_size = recv(fd, recv_buffer, JUST1RCE_SRCS_CLIENT_MSG_MAX, 0);
+    recv_size =
+        recv(fd, recv_buffer, JUST1RCE_SRCS_CLIENT_MSG_MAX, MSG_NOSIGNAL);
     // connection destructed, EPOLLHUP
     if (recv_size == 0) {
       return false;

--- a/srcs/client/client_send_message.cc
+++ b/srcs/client/client_send_message.cc
@@ -29,8 +29,8 @@ void Client::SetSendMessage(std::string const &message) {
  * @return if true, write_buffer_ has content to send, re-register write event
  */
 bool Client::SendMessage() {
-  ssize_t send_size =
-      send(socket_.socket_fd(), write_buffer_.c_str(), write_buffer_.size(), 0);
+  ssize_t send_size = send(socket_.socket_fd(), write_buffer_.c_str(),
+                           write_buffer_.size(), MSG_NOSIGNAL);
   if (send_size == -1) {
     if (errno == EAGAIN || errno == EWOULDBLOCK) {
       return true;  // re-register the write event

--- a/srcs/service/run_irc_server.cc
+++ b/srcs/service/run_irc_server.cc
@@ -42,7 +42,12 @@ void Service::RunIrcServer(std::string const &port_number,
       if (event_buffer[i].data.fd == server.socket_fd()) {
         HandleServerEvent(epoll_fd, event_buffer[i]);
       } else {
-        HandleClientEvent(epoll_fd, cmd_map, event_buffer[i]);
+        try {
+          HandleClientEvent(epoll_fd, cmd_map, event_buffer[i]);
+        } catch (const std::exception &e) {
+          RunCommand(epoll_fd, cmd_map, event_buffer[i],
+                     "QUIT :unexpected connection destroyed");
+        }
       }
     }
   }


### PR DESCRIPTION
# Socket 관련 error 처리 추가 \#140 
## Overview
socket의 비정상적인 종료 시 signal이 발생하며 서버가 강제로 종료되는 상황을 식별함. 이를 해결하기 위해서 에러 처리 코드를 추가.

## PR Type
recv와 send 호출 시 signal의 생성을 무시하도록 하여 std::runtime_error를 throw할 수 있도록 처리.
이후 throw된 exception을 catch하여 해당 socket에 연결된 client를 삭제.

- [x] fix

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
