### PR TITLE
#144,#149 fix: NICK, PASS명령어오류 해결

### DIFF
--- a/srcs/commands/nick_command_handler.cc
+++ b/srcs/commands/nick_command_handler.cc
@@ -73,7 +73,7 @@ std::vector<int> NickCommandHandler::operator()(const int client_fd,
 
     client->SetSendMessage(response);
     return std::vector<int>(1, client_fd);
-  } else {
+  } else if (old_nickname.empty() == false) {
     std::vector<int> fd_list;
     AnnounceNickChanged(client, old_nickname, new_nickname, &fd_list);
 
@@ -127,7 +127,7 @@ void NickCommandHandler::AnnounceNickChanged(Client* client,
  * - ERR_NICKNAMEINUSE(433): Nickname is already in use
  */
 int NickCommandHandler::CheckNick(const std::string& new_nickname) {
-  if (new_nickname.size() == 0) {
+  if (new_nickname.empty() == true) {
     return ERR_NONICKNAMEGIVEN;
   }
 

--- a/srcs/commands/pass_command_handler.cc
+++ b/srcs/commands/pass_command_handler.cc
@@ -44,6 +44,17 @@ std::vector<int> PassCommandHandler::operator()(const int client_fd,
   std::string password;
   Parser parser(message);
   parser.ParseCommandPass(&password);
+  std::vector<std::string> token_stream = parser.GetTokenStream();
+
+  if (token_stream.size() < 2) {
+    ResponseGenerator& generator = ResponseGenerator::GetInstance();
+    std::string response = generator.GenerateResponse(
+        ERR_NEEDMOREPARAMS,
+        ResponseArguments(ERR_NEEDMOREPARAMS, *client, NULL, token_stream));
+
+    client->SetSendMessage(response);
+    return std::vector<int>(1, client_fd);
+  }
 
   // Get numeric
   int numeric = CheckPass(*client, password);

--- a/srcs/commands/privmsg_command_handler.cc
+++ b/srcs/commands/privmsg_command_handler.cc
@@ -76,7 +76,7 @@ std::vector<int> PrivmsgCommandHandler::operator()(const int client_fd,
   // ERR_CANNOTSENDTOCHAN (404): Cannot send to channel
   if (target_name[0] == '#' || target_name[0] == '&') {
     Channel *channel = db->GetChannel(target_name);
-    if (channel == NULL || IsUserOnChannel(client_fd, *channel)) {
+    if (channel == NULL || IsUserOnChannel(client_fd, *channel) == false) {
       ResponseAsNumeric(client, token_stream, ERR_CANNOTSENDTOCHAN);
       return std::vector<int>(1, client_fd);
     }
@@ -119,6 +119,9 @@ static void SendPrivmsgToChannel(const Client &client, const Channel &channel,
       ":" + client_fullname + " PRIVMSG " + channel.name() + " :" + message;
 
   for (size_t index = 0; index < clients.size(); ++index) {
+    if (client.GetFd() == clients[index]->GetFd()) {
+      continue;
+    }
     Client *client = clients[index];
     client->SetSendMessage(response);
     fd_list->push_back(client->GetFd());

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -109,7 +109,7 @@ void ResponseGenerator::InitializeTemplates() {
       ":%s 475 %c %h :Cannot join channel (+k)";
   response_templates_[ERR_BADCHANMASK] = ":%s 476 %h :Bad Channel Mask";
   response_templates_[ERR_CHANOPRIVSNEEDED] =
-      ":%s 482 %c %h :You're not channel operator";
+      ":%s 482 %h :You're not channel operator";
 }
 
 /**

--- a/srcs/responser/response_generator.cc
+++ b/srcs/responser/response_generator.cc
@@ -46,7 +46,7 @@ ResponseArguments::ResponseArguments(const int numeric, const Client& client,
         ContextHolder::GetInstance()->db()->GetClientsByChannelName(
             channel->name()),
         &nicknames);
-  } else {
+  } else if (params.size() > 1) {
     nicknames = params[1];
   }
 }


### PR DESCRIPTION
# NICK 명령어오류 해결 \#144
## Overview
- NICK: 인증이 되지 않은상태에서 닉네임 변경 메시지를 보내는 문제 해결
- PASS: 파라미터가 제대로 들어오지 않은 경우 처리
- Responser: 인자로 들어온 매개변수 params 의 range를 확인하는 조건문 추가
