### PR TITLE
#164 fix: return initialized fd_list

### DIFF
--- a/srcs/commands/topic_command_handler.cc
+++ b/srcs/commands/topic_command_handler.cc
@@ -86,7 +86,7 @@ std::vector<int> TopicCommandHandler::operator()(const int client_fd,
   channel->set_topic(topic);
   BroadcastTopic(*client, channel, &fd_list);
 
-  return std::vector<int>();
+  return fd_list;
 }
 
 static int CheckNumericError(const Client& client, const Channel* channel) {


### PR DESCRIPTION
# bug fix \#164
## Overview
TOPIC 커맨드 핸들러에서 잘못된 fd_list를 반환하느라 server의 응답이 pending되는 현상 수정

## PR Type
어떤 변경 사항이 있나요?

- [x] fix

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
